### PR TITLE
WIP Feature/websocket scaffolding

### DIFF
--- a/internal/ws/mock/conn.go
+++ b/internal/ws/mock/conn.go
@@ -8,68 +8,83 @@ import (
 	"github.com/rabbytesoftware/quiver/internal/ws"
 )
 
-type state struct {
-	closed chan struct{}
-	once   sync.Once
-}
-
 type frame struct {
 	data []byte
 	typ  ws.MessageType
 }
 
 type Conn struct {
-	in  chan frame
-	out chan frame
-	st  *state
+	in       chan frame
+	out      chan frame
+	closed   chan struct{}
+	peerDone chan struct{}
+	once     sync.Once
 }
 
 func newPair() (*Conn, *Conn) {
 	aIn := make(chan frame, 16)
-
 	bIn := make(chan frame, 16)
 
-	st := &state{
-		closed: make(chan struct{}),
-	}
+	aClosed := make(chan struct{})
+	bClosed := make(chan struct{})
 
 	return &Conn{
-			in:  aIn,
-			out: bIn,
-			st:  st,
+			in:       aIn,
+			out:      bIn,
+			closed:   aClosed,
+			peerDone: bClosed,
 		},
 		&Conn{
-			in:  bIn,
-			out: aIn,
-			st:  st,
+			in:       bIn,
+			out:      aIn,
+			closed:   bClosed,
+			peerDone: aClosed,
 		}
 }
 
 func (c *Conn) Read(ctx context.Context) ([]byte, ws.MessageType, error) {
-	select {
-	case <-ctx.Done():
-		return nil, 0, ctx.Err()
-	case <-c.st.closed:
-		return nil, 0, errors.New("connection closed")
-	case f := <-c.in:
-		return f.data, f.typ, nil
+	if err := ctx.Err(); err != nil {
+		return nil, 0, err
 	}
+	select {
+	case <-c.closed:
+		return nil, 0, errors.New("connection closed")
+	default:
+	}
+	select {
+	case <-c.peerDone:
+		return nil, 0, errors.New("peer closed connection")
+	default:
+	}
+
+	f := <-c.in
+	return f.data, f.typ, nil
+
 }
 
 func (c *Conn) Write(ctx context.Context, data []byte, typ ws.MessageType) error {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-c.st.closed:
-		return errors.New("connection closed")
-	case c.out <- frame{data: data, typ: typ}:
-		return nil
+	if err := ctx.Err(); err != nil {
+		return err
 	}
+	select {
+	case <-c.closed:
+		return errors.New("connection closed")
+	default:
+	}
+	select {
+	case <-c.peerDone:
+		return errors.New("peer closed connection")
+	default:
+	}
+
+	c.out <- frame{data: data, typ: typ}
+	return nil
+
 }
 
 func (c *Conn) Close(code int, reason string) error {
-	c.st.once.Do(func() {
-		close(c.st.closed)
+	c.once.Do(func() {
+		close(c.closed)
 	})
 	return nil
 }

--- a/internal/ws/mock/conn.go
+++ b/internal/ws/mock/conn.go
@@ -1,0 +1,75 @@
+package mock
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/rabbytesoftware/quiver/internal/ws"
+)
+
+type state struct {
+	closed chan struct{}
+	once   sync.Once
+}
+
+type frame struct {
+	data []byte
+	typ  ws.MessageType
+}
+
+type Conn struct {
+	in  chan frame
+	out chan frame
+	st  *state
+}
+
+func newPair() (*Conn, *Conn) {
+	aIn := make(chan frame, 16)
+
+	bIn := make(chan frame, 16)
+
+	st := &state{
+		closed: make(chan struct{}),
+	}
+
+	return &Conn{
+			in:  aIn,
+			out: bIn,
+			st:  st,
+		},
+		&Conn{
+			in:  bIn,
+			out: aIn,
+			st:  st,
+		}
+}
+
+func (c *Conn) Read(ctx context.Context) ([]byte, ws.MessageType, error) {
+	select {
+	case <-ctx.Done():
+		return nil, 0, ctx.Err()
+	case <-c.st.closed:
+		return nil, 0, errors.New("connection closed")
+	case f := <-c.in:
+		return f.data, f.typ, nil
+	}
+}
+
+func (c *Conn) Write(ctx context.Context, data []byte, typ ws.MessageType) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.st.closed:
+		return errors.New("connection closed")
+	case c.out <- frame{data: data, typ: typ}:
+		return nil
+	}
+}
+
+func (c *Conn) Close(code int, reason string) error {
+	c.st.once.Do(func() {
+		close(c.st.closed)
+	})
+	return nil
+}

--- a/internal/ws/mock/conn.go
+++ b/internal/ws/mock/conn.go
@@ -2,67 +2,99 @@ package mock
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
+	"io"
+	"net"
 	"sync"
+	"time"
 
 	"github.com/rabbytesoftware/quiver/internal/ws"
 )
 
 type frame struct {
+	typ  ws.FrameType
 	data []byte
-	typ  ws.MessageType
+}
+
+type frameHeader struct {
+	Type   uint8
+	Length uint32
 }
 
 type Conn struct {
-	in       chan frame
-	out      chan frame
-	closed   chan struct{}
-	peerDone chan struct{}
-	once     sync.Once
+	conn      net.Conn
+	in        chan frame
+	out       chan frame
+	closed    chan struct{}
+	peerDone  chan struct{}
+	writeDone chan struct{}
+
+	workers []ConnWorker
+
+	once sync.Once
 }
 
-func newPair() (*Conn, *Conn) {
-	aIn := make(chan frame, 16)
-	bIn := make(chan frame, 16)
+type ConnWorker func(ctx context.Context, c *Conn)
 
-	aClosed := make(chan struct{})
-	bClosed := make(chan struct{})
+type ConnOption func(*Conn)
 
-	return &Conn{
-			in:       aIn,
-			out:      bIn,
-			closed:   aClosed,
-			peerDone: bClosed,
-		},
-		&Conn{
-			in:       bIn,
-			out:      aIn,
-			closed:   bClosed,
-			peerDone: aClosed,
-		}
-}
-
-func (c *Conn) Read(ctx context.Context) ([]byte, ws.MessageType, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, 0, err
+func WithWorker(w ConnWorker) ConnOption {
+	return func(c *Conn) {
+		c.workers = append(c.workers, w)
 	}
+}
+
+func NewPair(ctx context.Context, opts ...ConnOption) (*Conn, *Conn) {
+	a, b := net.Pipe()
+
+	c1 := NewConn(ctx, a, opts...)
+	c2 := NewConn(ctx, b, opts...)
+
+	return c1, c2
+}
+
+func NewConn(ctx context.Context, nc net.Conn, opts ...ConnOption) *Conn {
+	c := &Conn{
+		conn:      nc,
+		in:        make(chan frame, 16),
+		out:       make(chan frame, 16),
+		closed:    make(chan struct{}),
+		peerDone:  make(chan struct{}),
+		writeDone: make(chan struct{}),
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	go c.readLoop(ctx)
+	go c.writeLoop(ctx)
+
+	for _, w := range c.workers {
+		go w(ctx, c)
+	}
+
+	return c
+}
+
+func (c *Conn) Read(ctx context.Context) ([]byte, ws.FrameType, error) {
 	select {
+	case <-ctx.Done():
+		return nil, 0, ctx.Err()
+
 	case <-c.closed:
 		return nil, 0, errors.New("connection closed")
-	default:
-	}
-	select {
+
 	case <-c.peerDone:
 		return nil, 0, errors.New("peer closed connection")
-	default:
+
+	case f := <-c.in:
+		return f.data, f.typ, nil
 	}
-
-	f := <-c.in
-	return f.data, f.typ, nil
-
 }
 
-func (c *Conn) Write(ctx context.Context, data []byte, typ ws.MessageType) error {
+func (c *Conn) Write(ctx context.Context, data []byte, typ ws.FrameType) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -85,6 +117,117 @@ func (c *Conn) Write(ctx context.Context, data []byte, typ ws.MessageType) error
 func (c *Conn) Close(code int, reason string) error {
 	c.once.Do(func() {
 		close(c.closed)
+
+		// Wait for all queued writes to flush
+		<-c.writeDone
+
+		_ = c.conn.Close()
 	})
+
 	return nil
+}
+
+func (c *Conn) closePeer() {
+	c.once.Do(func() {
+		close(c.peerDone)
+	})
+}
+
+func (c *Conn) writeLoop(ctx context.Context) {
+	defer close(c.writeDone)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case <-c.closed:
+			return
+
+		case <-c.peerDone:
+			return
+
+		case f := <-c.out:
+			if err := writeFrame(c.conn, f); err != nil {
+				return
+			}
+		}
+	}
+}
+
+var readFrameFn = readFrame
+
+func (c *Conn) readLoop(ctx context.Context) {
+	for {
+		f, err := readFrameFn(c.conn)
+		if err != nil {
+			c.closePeer()
+			return
+		}
+
+		select {
+		case <-ctx.Done():
+			c.closePeer()
+			return
+
+		case <-c.closed:
+			c.closePeer()
+			return
+
+		case c.in <- f:
+		}
+	}
+}
+
+func writeFrame(w io.Writer, f frame) error {
+	hdr := frameHeader{
+		Type:   uint8(f.typ),
+		Length: uint32(len(f.data)),
+	}
+
+	if err := binary.Write(w, binary.BigEndian, hdr); err != nil {
+		return err
+	}
+	_, err := w.Write(f.data)
+	return err
+}
+
+func readFrame(r io.Reader) (frame, error) {
+	var hdr frameHeader
+
+	if err := binary.Read(r, binary.BigEndian, &hdr); err != nil {
+		return frame{}, err
+	}
+
+	data := make([]byte, hdr.Length)
+	if _, err := io.ReadFull(r, data); err != nil {
+		return frame{}, err
+	}
+
+	return frame{
+		typ:  ws.FrameType(hdr.Type),
+		data: data,
+	}, nil
+}
+
+// HelloWorldWorker returns a ConnWorker that sends "hello world" messages
+// at the specified interval. FOR TESTING PURPOSES ONLY.
+func HelloWorldWorker(interval time.Duration) ConnWorker {
+	return func(ctx context.Context, c *Conn) {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-c.closed:
+				return
+			case <-c.peerDone:
+				return
+			case <-ticker.C:
+				_ = c.Write(ctx, []byte("hello world"), ws.TextFrame)
+			}
+		}
+	}
 }

--- a/internal/ws/mock/endpoint.go
+++ b/internal/ws/mock/endpoint.go
@@ -1,0 +1,43 @@
+package mock
+
+import (
+	"context"
+
+	"github.com/rabbytesoftware/quiver/internal/ws"
+)
+
+type Listener struct {
+	conns chan ws.Conn
+}
+
+func NewListener() *Listener {
+	return &Listener{conns: make(chan ws.Conn, 8)}
+}
+
+func (l *Listener) Upgrade(ctx context.Context) (ws.Conn, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case conn := <-l.conns:
+		return conn, nil
+	}
+}
+
+type Dialer struct {
+	listener *Listener
+}
+
+func NewDialer(l *Listener) *Dialer {
+	return &Dialer{listener: l}
+}
+
+func (d *Dialer) Dial(ctx context.Context, addr string) (ws.Conn, error) {
+	c1, c2 := newPair()
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case d.listener.conns <- c2:
+		return c1, nil
+	}
+}

--- a/internal/ws/mock/endpoint.go
+++ b/internal/ws/mock/endpoint.go
@@ -36,7 +36,7 @@ func (d *Dialer) Dial(ctx context.Context, addr string) (ws.Conn, error) {
 		return nil, err
 	}
 
-	c1, c2 := newPair()
+	c1, c2 := NewPair(ctx)
 
 	d.listener.conns <- c2
 	return c1, nil

--- a/internal/ws/mock/endpoint.go
+++ b/internal/ws/mock/endpoint.go
@@ -15,12 +15,12 @@ func NewListener() *Listener {
 }
 
 func (l *Listener) Upgrade(ctx context.Context) (ws.Conn, error) {
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case conn := <-l.conns:
-		return conn, nil
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
+
+	conn := <-l.conns
+	return conn, nil
 }
 
 type Dialer struct {
@@ -32,12 +32,12 @@ func NewDialer(l *Listener) *Dialer {
 }
 
 func (d *Dialer) Dial(ctx context.Context, addr string) (ws.Conn, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	c1, c2 := newPair()
 
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case d.listener.conns <- c2:
-		return c1, nil
-	}
+	d.listener.conns <- c2
+	return c1, nil
 }

--- a/internal/ws/mock/mock_test.go
+++ b/internal/ws/mock/mock_test.go
@@ -1,7 +1,10 @@
 package mock
 
 import (
+	"bytes"
 	"context"
+	"io"
+	"net"
 	"sync"
 	"testing"
 	"time"
@@ -43,7 +46,7 @@ func TestMockWebSocketLifecycle(t *testing.T) {
 	}
 	defer clientConn.Close(1000, "client closed")
 
-	if err := clientConn.Write(ctx, []byte("hello"), ws.Text); err != nil {
+	if err := clientConn.Write(ctx, []byte("hello"), ws.TextFrame); err != nil {
 		t.Fatal("Write failed:", err)
 	}
 
@@ -51,7 +54,7 @@ func TestMockWebSocketLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatal("Read failed:", err)
 	}
-	if string(msg) != "hello" || typ != ws.Text {
+	if string(msg) != "hello" || typ != ws.TextFrame {
 		t.Errorf("Expected message 'hello' and type Text, got message '%s' and type %d", string(msg), typ)
 	}
 
@@ -90,40 +93,39 @@ func TestMockWebSocketContextCancellation(t *testing.T) {
 }
 
 func TestNewPairCreatesConnectedConns(t *testing.T) {
-	c1, c2 := newPair()
+	ctx := context.Background()
+	c1, c2 := NewPair(ctx)
 	defer c1.Close(1000, "test done")
 	defer c2.Close(1000, "test done")
 
-	ctx := context.Background()
 	testMsg := []byte("test message")
 
-	if err := c1.Write(ctx, testMsg, ws.Text); err != nil {
+	if err := c1.Write(ctx, testMsg, ws.TextFrame); err != nil {
 		t.Fatal("c1 Write failed:", err)
 	}
 	msg, typ, err := c2.Read(ctx)
 	if err != nil {
 		t.Fatal("c2 Read failed:", err)
 	}
-	if string(msg) != string(testMsg) || typ != ws.Text {
+	if string(msg) != string(testMsg) || typ != ws.TextFrame {
 		t.Errorf("Expected message '%s' and type Text, got message '%s' and type %d", string(testMsg), string(msg), typ)
 	}
 
-	if err := c2.Write(ctx, testMsg, ws.Binary); err != nil {
+	if err := c2.Write(ctx, testMsg, ws.TextFrame); err != nil {
 		t.Fatal("c2 Write failed:", err)
 	}
 	msg, typ, err = c1.Read(ctx)
 	if err != nil {
 		t.Fatal("c1 Read failed:", err)
 	}
-	if string(msg) != string(testMsg) || typ != ws.Binary {
+	if string(msg) != string(testMsg) || typ != ws.TextFrame {
 		t.Errorf("Expected message '%s' and type Binary, got message '%s' and type %d", string(testMsg), string(msg), typ)
 	}
 }
 
 func TestReadConnectionClosed(t *testing.T) {
-	c1, c2 := newPair()
-
 	ctx := context.Background()
+	c1, c2 := NewPair(ctx)
 	c1.Close(1000, "closing connection")
 
 	_, _, err := c2.Read(ctx)
@@ -132,13 +134,13 @@ func TestReadConnectionClosed(t *testing.T) {
 	}
 }
 func TestWriteConnectionClosed(t *testing.T) {
-	c1, c2 := newPair()
-
 	ctx := context.Background()
+	c1, c2 := NewPair(ctx)
+
 	c1.Close(1000, "closing connection")
 	time.Sleep(10 * time.Millisecond) // Ensure close propagates
 
-	err := c2.Write(ctx, []byte("data"), ws.Text)
+	err := c2.Write(ctx, []byte("data"), ws.TextFrame)
 	if err == nil {
 		t.Fatal("Expected Write to fail due to closed peer:")
 	}
@@ -151,7 +153,7 @@ func TestWriteConnectionClosed(t *testing.T) {
 	c2.Close(1000, "closing peer")
 	time.Sleep(10 * time.Millisecond) // Ensure close propagates
 
-	err = c1.Write(ctx, []byte("data"), ws.Text)
+	err = c1.Write(ctx, []byte("data"), ws.TextFrame)
 	if err == nil {
 		t.Fatal("Expected Write to fail due to own closed connection:")
 	}
@@ -163,7 +165,8 @@ func TestWriteConnectionClosed(t *testing.T) {
 }
 
 func TestCloseIdempotent(t *testing.T) {
-	c1, c2 := newPair()
+	ctx := context.Background()
+	c1, c2 := NewPair(ctx)
 
 	err1 := c1.Close(1000, "first close")
 	err2 := c2.Close(1000, "second close")
@@ -179,7 +182,7 @@ func TestCloseIdempotent(t *testing.T) {
 func TestContextCancellation(t *testing.T) {
 	listener := NewListener()
 	dialer := NewDialer(listener)
-	c1, c2 := newPair()
+	c1, c2 := NewPair(context.Background())
 	defer c1.Close(1000, "test done")
 	defer c2.Close(1000, "test done")
 
@@ -192,7 +195,7 @@ func TestContextCancellation(t *testing.T) {
 		t.Fatal("Expected Read to fail due to context cancellation")
 	}
 
-	err = c2.Write(ctx, []byte("data"), ws.Text)
+	err = c2.Write(ctx, []byte("data"), ws.TextFrame)
 	if err == nil {
 		t.Fatal("Expected Write to fail due to context cancellation")
 	}
@@ -209,7 +212,7 @@ func TestContextCancellation(t *testing.T) {
 }
 
 func TestClose(t *testing.T) {
-	c1, c2 := newPair()
+	c1, c2 := NewPair(context.Background())
 
 	err := c1.Close(1000, "closing connection")
 	if err != nil {
@@ -224,5 +227,118 @@ func TestClose(t *testing.T) {
 	err = c1.Close(1000, "closing again")
 	if err != nil {
 		t.Fatal("Second Close failed:", err)
+	}
+}
+
+func TestWriteReadFrame(t *testing.T) {
+	var buf bytes.Buffer
+
+	want := frame{typ: 0, data: []byte("hi")}
+
+	if err := writeFrame(&buf, want); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := readFrame(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(got.data, want.data) {
+		t.Fatalf("got %q, want %q", got.data, want.data)
+	}
+}
+
+func TestHelloWorldWorker(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server, client := net.Pipe()
+	defer client.Close()
+
+	_ = NewConn(
+		ctx,
+		server,
+		WithWorker(HelloWorldWorker(10*time.Millisecond)),
+	)
+
+	// read raw frame from the client side
+	f, err := readFrame(client)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(f.data) != "hello world" {
+		t.Fatalf("got %q, want hello world", f.data)
+	}
+}
+
+func TestReadLoop_ContextDone(t *testing.T) {
+	c := &Conn{
+		in:       make(chan frame),
+		closed:   make(chan struct{}),
+		peerDone: make(chan struct{}),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	readFrameFn = func(_ io.Reader) (frame, error) {
+		return frame{data: []byte("hello")}, nil
+	}
+
+	defer func() { readFrameFn = readFrame }()
+
+	go c.readLoop(ctx)
+
+	time.Sleep(10 * time.Millisecond) // Allow goroutine to exit
+
+	cancel()
+
+	time.Sleep(10 * time.Millisecond) // Allow cancellation to propagate
+	select {
+	case <-c.peerDone:
+	// success
+	case <-time.After(time.Second):
+		t.Fatal("peerDone was not closed on ctx.Done")
+	}
+
+	select {
+	case <-c.in:
+		t.Fatal("frame should not be delivered after ctx.Done")
+	default:
+		// success
+	}
+}
+
+func TestReadLoop_ConnClosed(t *testing.T) {
+	c := &Conn{
+		in:       make(chan frame),
+		closed:   make(chan struct{}),
+		peerDone: make(chan struct{}),
+	}
+	ctx := context.Background()
+
+	readFrameFn = func(_ io.Reader) (frame, error) {
+		return frame{data: []byte("hello")}, nil
+	}
+	defer func() { readFrameFn = readFrame }()
+
+	go c.readLoop(ctx)
+
+	// Simulate local Close()
+	close(c.closed)
+
+	select {
+	case <-c.peerDone:
+		// OK
+	case <-time.After(time.Second):
+		t.Fatal("peerDone was not closed on c.closed")
+	}
+
+	select {
+	case <-c.in:
+		t.Fatal("frame should not be delivered after c.closed")
+	default:
+		// OK
 	}
 }

--- a/internal/ws/mock/mock_test.go
+++ b/internal/ws/mock/mock_test.go
@@ -1,4 +1,4 @@
-package mock_test
+package mock
 
 import (
 	"context"
@@ -7,12 +7,11 @@ import (
 	"time"
 
 	"github.com/rabbytesoftware/quiver/internal/ws"
-	"github.com/rabbytesoftware/quiver/internal/ws/mock"
 )
 
 func TestMockWebSocketLifecycle(t *testing.T) {
-	listener := mock.NewListener()
-	dialer := mock.NewDialer(listener)
+	listener := NewListener()
+	dialer := NewDialer(listener)
 
 	ctx := context.Background()
 	var wg sync.WaitGroup
@@ -69,5 +68,156 @@ func TestMockWebSocketLifecycle(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("server goroutine timed out")
+	}
+}
+
+func TestMockWebSocketContextCancellation(t *testing.T) {
+	listener := NewListener()
+	dialer := NewDialer(listener)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	_, err := dialer.Dial(ctx, "mock://ws")
+	if err == nil {
+		t.Fatal("Expected Dial to fail due to context cancellation")
+	}
+
+	_, err = listener.Upgrade(ctx)
+	if err == nil {
+		t.Fatal("Expected Upgrade to fail due to context cancellation")
+	}
+}
+
+func TestNewPairCreatesConnectedConns(t *testing.T) {
+	c1, c2 := newPair()
+	defer c1.Close(1000, "test done")
+	defer c2.Close(1000, "test done")
+
+	ctx := context.Background()
+	testMsg := []byte("test message")
+
+	if err := c1.Write(ctx, testMsg, ws.Text); err != nil {
+		t.Fatal("c1 Write failed:", err)
+	}
+	msg, typ, err := c2.Read(ctx)
+	if err != nil {
+		t.Fatal("c2 Read failed:", err)
+	}
+	if string(msg) != string(testMsg) || typ != ws.Text {
+		t.Errorf("Expected message '%s' and type Text, got message '%s' and type %d", string(testMsg), string(msg), typ)
+	}
+
+	if err := c2.Write(ctx, testMsg, ws.Binary); err != nil {
+		t.Fatal("c2 Write failed:", err)
+	}
+	msg, typ, err = c1.Read(ctx)
+	if err != nil {
+		t.Fatal("c1 Read failed:", err)
+	}
+	if string(msg) != string(testMsg) || typ != ws.Binary {
+		t.Errorf("Expected message '%s' and type Binary, got message '%s' and type %d", string(testMsg), string(msg), typ)
+	}
+}
+
+func TestReadConnectionClosed(t *testing.T) {
+	c1, c2 := newPair()
+
+	ctx := context.Background()
+	c1.Close(1000, "closing connection")
+
+	_, _, err := c2.Read(ctx)
+	if err == nil {
+		t.Fatal("Expected Read to fail due to closed connection")
+	}
+}
+func TestWriteConnectionClosed(t *testing.T) {
+	c1, c2 := newPair()
+
+	ctx := context.Background()
+	c1.Close(1000, "closing connection")
+	time.Sleep(10 * time.Millisecond) // Ensure close propagates
+
+	err := c2.Write(ctx, []byte("data"), ws.Text)
+	if err == nil {
+		t.Fatal("Expected Write to fail due to closed peer:")
+	}
+
+	_, _, err = c2.Read(ctx)
+	if err == nil {
+		t.Fatal("Expected Read to fail due to closed peer")
+	}
+
+	c2.Close(1000, "closing peer")
+	time.Sleep(10 * time.Millisecond) // Ensure close propagates
+
+	err = c1.Write(ctx, []byte("data"), ws.Text)
+	if err == nil {
+		t.Fatal("Expected Write to fail due to own closed connection:")
+	}
+
+	_, _, err = c1.Read(ctx)
+	if err == nil {
+		t.Fatal("Expected Read to fail due to own closed connection")
+	}
+}
+
+func TestCloseIdempotent(t *testing.T) {
+	c1, c2 := newPair()
+
+	err1 := c1.Close(1000, "first close")
+	err2 := c2.Close(1000, "second close")
+
+	if err1 != nil {
+		t.Fatal("First Closed failed:", err1)
+	}
+	if err2 != nil {
+		t.Fatal("Second Close failed:", err2)
+	}
+}
+
+func TestContextCancellation(t *testing.T) {
+	listener := NewListener()
+	dialer := NewDialer(listener)
+	c1, c2 := newPair()
+	defer c1.Close(1000, "test done")
+	defer c2.Close(1000, "test done")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()                         // Cancel immediately
+	time.Sleep(5 * time.Millisecond) // Ensure cancellation propagates
+
+	_, _, err := c1.Read(ctx)
+	if err == nil {
+		t.Fatal("Expected Read to fail due to context cancellation")
+	}
+
+	err = c2.Write(ctx, []byte("data"), ws.Text)
+	if err == nil {
+		t.Fatal("Expected Write to fail due to context cancellation")
+	}
+
+	_, err = dialer.Dial(ctx, "mock://ws")
+	if err == nil {
+		t.Fatal("Expected Dial to fail due to context cancellation")
+	}
+
+	_, err = listener.Upgrade(ctx)
+	if err == nil {
+		t.Fatal("Expected Upgrade to fail due to context cancellation")
+	}
+}
+
+func TestClose(t *testing.T) {
+	c1, c2 := newPair()
+
+	err := c1.Close(1000, "closing connection")
+	if err != nil {
+		t.Fatal("Close failed:", err)
+	}
+
+	err = c2.Close(1000, "closing peer")
+	if err != nil {
+		t.Fatal("Close failed:", err)
 	}
 }

--- a/internal/ws/mock/mock_test.go
+++ b/internal/ws/mock/mock_test.go
@@ -1,0 +1,73 @@
+package mock_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rabbytesoftware/quiver/internal/ws"
+	"github.com/rabbytesoftware/quiver/internal/ws/mock"
+)
+
+func TestMockWebSocketLifecycle(t *testing.T) {
+	listener := mock.NewListener()
+	dialer := mock.NewDialer(listener)
+
+	ctx := context.Background()
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	var srvErr error
+	go func() {
+		defer wg.Done()
+
+		srvConn, err := listener.Upgrade(ctx)
+		if err != nil {
+			srvErr = err
+			return
+		}
+		defer srvConn.Close(1000, "server closed")
+
+		msg, typ, err := srvConn.Read(ctx)
+		if err != nil {
+			srvErr = err
+			return
+		}
+
+		srvErr = srvConn.Write(ctx, msg, typ)
+	}()
+
+	clientConn, err := dialer.Dial(ctx, "mock://ws")
+	if err != nil {
+		t.Fatal("Dial failed:", err)
+	}
+	defer clientConn.Close(1000, "client closed")
+
+	if err := clientConn.Write(ctx, []byte("hello"), ws.Text); err != nil {
+		t.Fatal("Write failed:", err)
+	}
+
+	msg, typ, err := clientConn.Read(ctx)
+	if err != nil {
+		t.Fatal("Read failed:", err)
+	}
+	if string(msg) != "hello" || typ != ws.Text {
+		t.Errorf("Expected message 'hello' and type Text, got message '%s' and type %d", string(msg), typ)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		if srvErr != nil {
+			t.Fatal(srvErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("server goroutine timed out")
+	}
+}

--- a/internal/ws/mock/mock_test.go
+++ b/internal/ws/mock/mock_test.go
@@ -1,4 +1,4 @@
-package mock_test
+package mock
 
 import (
 	"context"
@@ -7,12 +7,11 @@ import (
 	"time"
 
 	"github.com/rabbytesoftware/quiver/internal/ws"
-	"github.com/rabbytesoftware/quiver/internal/ws/mock"
 )
 
 func TestMockWebSocketLifecycle(t *testing.T) {
-	listener := mock.NewListener()
-	dialer := mock.NewDialer(listener)
+	listener := NewListener()
+	dialer := NewDialer(listener)
 
 	ctx := context.Background()
 	var wg sync.WaitGroup
@@ -69,5 +68,161 @@ func TestMockWebSocketLifecycle(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("server goroutine timed out")
+	}
+}
+
+func TestMockWebSocketContextCancellation(t *testing.T) {
+	listener := NewListener()
+	dialer := NewDialer(listener)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	_, err := dialer.Dial(ctx, "mock://ws")
+	if err == nil {
+		t.Fatal("Expected Dial to fail due to context cancellation")
+	}
+
+	_, err = listener.Upgrade(ctx)
+	if err == nil {
+		t.Fatal("Expected Upgrade to fail due to context cancellation")
+	}
+}
+
+func TestNewPairCreatesConnectedConns(t *testing.T) {
+	c1, c2 := newPair()
+	defer c1.Close(1000, "test done")
+	defer c2.Close(1000, "test done")
+
+	ctx := context.Background()
+	testMsg := []byte("test message")
+
+	if err := c1.Write(ctx, testMsg, ws.Text); err != nil {
+		t.Fatal("c1 Write failed:", err)
+	}
+	msg, typ, err := c2.Read(ctx)
+	if err != nil {
+		t.Fatal("c2 Read failed:", err)
+	}
+	if string(msg) != string(testMsg) || typ != ws.Text {
+		t.Errorf("Expected message '%s' and type Text, got message '%s' and type %d", string(testMsg), string(msg), typ)
+	}
+
+	if err := c2.Write(ctx, testMsg, ws.Binary); err != nil {
+		t.Fatal("c2 Write failed:", err)
+	}
+	msg, typ, err = c1.Read(ctx)
+	if err != nil {
+		t.Fatal("c1 Read failed:", err)
+	}
+	if string(msg) != string(testMsg) || typ != ws.Binary {
+		t.Errorf("Expected message '%s' and type Binary, got message '%s' and type %d", string(testMsg), string(msg), typ)
+	}
+}
+
+func TestReadConnectionClosed(t *testing.T) {
+	c1, c2 := newPair()
+
+	ctx := context.Background()
+	c1.Close(1000, "closing connection")
+
+	_, _, err := c2.Read(ctx)
+	if err == nil {
+		t.Fatal("Expected Read to fail due to closed connection")
+	}
+}
+func TestWriteConnectionClosed(t *testing.T) {
+	c1, c2 := newPair()
+
+	ctx := context.Background()
+	c1.Close(1000, "closing connection")
+	time.Sleep(10 * time.Millisecond) // Ensure close propagates
+
+	err := c2.Write(ctx, []byte("data"), ws.Text)
+	if err == nil {
+		t.Fatal("Expected Write to fail due to closed peer:")
+	}
+
+	_, _, err = c2.Read(ctx)
+	if err == nil {
+		t.Fatal("Expected Read to fail due to closed peer")
+	}
+
+	c2.Close(1000, "closing peer")
+	time.Sleep(10 * time.Millisecond) // Ensure close propagates
+
+	err = c1.Write(ctx, []byte("data"), ws.Text)
+	if err == nil {
+		t.Fatal("Expected Write to fail due to own closed connection:")
+	}
+
+	_, _, err = c1.Read(ctx)
+	if err == nil {
+		t.Fatal("Expected Read to fail due to own closed connection")
+	}
+}
+
+func TestCloseIdempotent(t *testing.T) {
+	c1, c2 := newPair()
+
+	err1 := c1.Close(1000, "first close")
+	err2 := c2.Close(1000, "second close")
+
+	if err1 != nil {
+		t.Fatal("First Closed failed:", err1)
+	}
+	if err2 != nil {
+		t.Fatal("Second Close failed:", err2)
+	}
+}
+
+func TestContextCancellation(t *testing.T) {
+	listener := NewListener()
+	dialer := NewDialer(listener)
+	c1, c2 := newPair()
+	defer c1.Close(1000, "test done")
+	defer c2.Close(1000, "test done")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()                         // Cancel immediately
+	time.Sleep(5 * time.Millisecond) // Ensure cancellation propagates
+
+	_, _, err := c1.Read(ctx)
+	if err == nil {
+		t.Fatal("Expected Read to fail due to context cancellation")
+	}
+
+	err = c2.Write(ctx, []byte("data"), ws.Text)
+	if err == nil {
+		t.Fatal("Expected Write to fail due to context cancellation")
+	}
+
+	_, err = dialer.Dial(ctx, "mock://ws")
+	if err == nil {
+		t.Fatal("Expected Dial to fail due to context cancellation")
+	}
+
+	_, err = listener.Upgrade(ctx)
+	if err == nil {
+		t.Fatal("Expected Upgrade to fail due to context cancellation")
+	}
+}
+
+func TestClose(t *testing.T) {
+	c1, c2 := newPair()
+
+	err := c1.Close(1000, "closing connection")
+	if err != nil {
+		t.Fatal("Close failed:", err)
+	}
+
+	err = c2.Close(1000, "closing peer")
+	if err != nil {
+		t.Fatal("Close failed:", err)
+	}
+
+	err = c1.Close(1000, "closing again")
+	if err != nil {
+		t.Fatal("Second Close failed:", err)
 	}
 }

--- a/internal/ws/ws.go
+++ b/internal/ws/ws.go
@@ -2,16 +2,16 @@ package ws
 
 import "context"
 
-type MessageType int
+type FrameType uint8
 
 const (
-	Text MessageType = iota
-	Binary
+	TextFrame FrameType = iota
+	BinaryFrame
 )
 
 type Conn interface {
-	Read(ctx context.Context) ([]byte, MessageType, error)
-	Write(ctx context.Context, data []byte, typ MessageType) error
+	Read(ctx context.Context) ([]byte, FrameType, error)
+	Write(ctx context.Context, data []byte, typ FrameType) error
 	Close(code int, reason string) error
 }
 

--- a/internal/ws/ws.go
+++ b/internal/ws/ws.go
@@ -22,3 +22,41 @@ type Dialer interface {
 type Upgrader interface {
 	Upgrade(ctx context.Context) (Conn, error)
 }
+
+type Handler interface {
+	OnOpen(ctx context.Context, c Conn) error
+
+	OnMessage(ctx context.Context, c Conn, data []byte, typ FrameType) error
+
+	OnError(ctx context.Context, c Conn, err error)
+
+	OnClose(ctx context.Context, c Conn, err error)
+}
+
+type HandlerFactory interface {
+	New(ctx context.Context, c Conn) Handler
+}
+
+func Serve(ctx context.Context, c Conn, h Handler) {
+	if err := h.OnOpen(ctx, c); err != nil {
+		_ = c.Close(1002, err.Error())
+		h.OnClose(ctx, c, err)
+		return
+	}
+
+	for {
+		data, typ, err := c.Read(ctx)
+		if err != nil {
+			h.OnError(ctx, c, err)
+			h.OnClose(ctx, c, err)
+			return
+		}
+
+		if err := h.OnMessage(ctx, c, data, typ); err != nil {
+			h.OnError(ctx, c, err)
+			_ = c.Close(1002, err.Error())
+			h.OnClose(ctx, c, err)
+			return
+		}
+	}
+}

--- a/internal/ws/ws.go
+++ b/internal/ws/ws.go
@@ -1,0 +1,24 @@
+package ws
+
+import "context"
+
+type MessageType int
+
+const (
+	Text MessageType = iota
+	Binary
+)
+
+type Conn interface {
+	Read(ctx context.Context) ([]byte, MessageType, error)
+	Write(ctx context.Context, data []byte, typ MessageType) error
+	Close(code int, reason string) error
+}
+
+type Dialer interface {
+	Dial(ctx context.Context, addr string) (Conn, error)
+}
+
+type Upgrader interface {
+	Upgrade(ctx context.Context) (Conn, error)
+}

--- a/internal/ws/ws_test.go
+++ b/internal/ws/ws_test.go
@@ -1,0 +1,214 @@
+package ws_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/rabbytesoftware/quiver/internal/ws"
+)
+
+type readResult struct {
+	data []byte
+	typ  ws.FrameType
+	err  error
+}
+
+type fakeConn struct {
+	mu sync.Mutex
+
+	reads []readResult
+	idx   int
+
+	closeCalled bool
+	closeCode   int
+	closeReason string
+}
+
+func (f *fakeConn) Read(ctx context.Context) ([]byte, ws.FrameType, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	// Respect context cancellation
+	select {
+	case <-ctx.Done():
+		return nil, 0, ctx.Err()
+	default:
+	}
+
+	if f.idx >= len(f.reads) {
+		return nil, 0, io.EOF
+	}
+
+	r := f.reads[f.idx]
+	f.idx++
+	return r.data, r.typ, r.err
+}
+
+func (f *fakeConn) Write(context.Context, []byte, ws.FrameType) error {
+	return nil
+}
+
+func (f *fakeConn) Close(code int, reason string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.closeCalled = true
+	f.closeCode = code
+	f.closeReason = reason
+	return nil
+}
+
+type call struct {
+	name string
+	err  error
+}
+
+type mockHandler struct {
+	calls []call
+
+	onOpenErr    error
+	onMessageErr error
+}
+
+func (m *mockHandler) OnOpen(ctx context.Context, c ws.Conn) error {
+	m.calls = append(m.calls, call{name: "open"})
+	return m.onOpenErr
+}
+
+func (m *mockHandler) OnMessage(ctx context.Context, c ws.Conn, _ []byte, _ ws.FrameType) error {
+	m.calls = append(m.calls, call{name: "message"})
+	return m.onMessageErr
+}
+
+func (m *mockHandler) OnError(ctx context.Context, c ws.Conn, err error) {
+	m.calls = append(m.calls, call{name: "error", err: err})
+}
+
+func (m *mockHandler) OnClose(ctx context.Context, c ws.Conn, err error) {
+	m.calls = append(m.calls, call{name: "close", err: err})
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestServe(t *testing.T) {
+	tests := []struct {
+		name string
+
+		ctx context.Context
+
+		reads []readResult
+
+		onOpenErr    error
+		onMessageErr error
+
+		wantCalls []string
+		wantClose bool
+	}{
+		{
+			name: "happy path, single message, EOF",
+			ctx:  context.Background(),
+			reads: []readResult{
+				{[]byte("hi"), ws.TextFrame, nil},
+				{nil, 0, io.EOF},
+			},
+			wantCalls: []string{
+				"open",
+				"message",
+				"error",
+				"close",
+			},
+		},
+		{
+			name:      "OnOpen error",
+			ctx:       context.Background(),
+			onOpenErr: errors.New("boom"),
+			wantCalls: []string{
+				"open",
+				"close",
+			},
+			wantClose: true,
+		},
+		{
+			name: "Read error",
+			ctx:  context.Background(),
+			reads: []readResult{
+				{nil, 0, errors.New("read failed")},
+			},
+			wantCalls: []string{
+				"open",
+				"error",
+				"close",
+			},
+		},
+		{
+			name: "OnMessage error",
+			ctx:  context.Background(),
+			reads: []readResult{
+				{[]byte("msg"), ws.TextFrame, nil},
+			},
+			onMessageErr: errors.New("handler failed"),
+			wantCalls: []string{
+				"open",
+				"message",
+				"error",
+				"close",
+			},
+			wantClose: true,
+		},
+		{
+			name: "context canceled",
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			}(),
+			wantCalls: []string{
+				"open",
+				"error",
+				"close",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn := &fakeConn{
+				reads: tt.reads,
+			}
+
+			h := &mockHandler{
+				onOpenErr:    tt.onOpenErr,
+				onMessageErr: tt.onMessageErr,
+			}
+
+			ws.Serve(tt.ctx, conn, h)
+
+			// Extract call names
+			var got []string
+			for _, c := range h.calls {
+				got = append(got, c.name)
+			}
+
+			if !equalStrings(got, tt.wantCalls) {
+				t.Fatalf("calls = %v, want %v", got, tt.wantCalls)
+			}
+
+			if tt.wantClose && !conn.closeCalled {
+				t.Fatalf("expected Conn.Close to be called")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
<!-- Brief description of changes -->
This PR will add WebSocket library with basic mocked operations as initial scaffolding to support the full WebSocket implementation.

## Type of Change
- [ ] 🐛 Bug fix (fix/*)
- [x] ✨ New feature (feature/*)
- [ ] 🔧 Enhancement (enhancement/*)
- [ ] 🚑 Hotfix (hotfix/*)
- [ ] 🚀 Release (release/*)

## Related Issues
Closes #85 

## Changes Made
<!-- List key changes -->
- Added ws library with Conn, Dialer, and Upgrader interfaces.
- Added mock operations and implementation.
- Added tests to cover all cases and operations of the mock implementation.
- Added Handler interface to define WebSocket connection lifecycle callbacks and optional HandlerFactory for per-connection handler instantiation
- Added Serve() function to manage WebSocket connection lifecycle and message dispatch.
- Added full unit tests for Serve(), covering success and failure paths.

## Acceptance criteria (to be completed before full PR and merge)
- [x] WebSocket handler interface defined with methods for connection lifecycle
- [x] Mock WebSocket implementation with basic connect/disconnect operations
- [ ] Message structure defined (JSON format for structured messages)
- [ ] Basic routing/handling for different message types (Following repository conventions and API scaffolding guidance)
- [ ] Integration with API layer (upgrade handler, route registration)
- [ ] Connection management (track connections, broadcast capability)
- [x] Unit tests for WebSocket handler interface and mock implementation
- [ ] Integration tests for WebSocket upgrade and basic message flow
- [ ] Documentation on WebSocket API structure and usage


