### PR TITLE
feat(engine): implement deptree engine

### DIFF
--- a/internal/engine/deptree/deptree.go
+++ b/internal/engine/deptree/deptree.go
@@ -1,1 +1,32 @@
 package deptree
+
+import (
+	"context"
+
+	"github.com/rabbytesoftware/quiver/internal/domain"
+)
+
+type ResolverFunc func(
+	ctx context.Context,
+	ns domain.Namespace,
+) ([]domain.Namespace, error)
+
+type DepTree func(
+	ctx context.Context,
+	root domain.Namespace,
+	resolver ResolverFunc,
+) ([]domain.Namespace, error)
+
+func Deptree(
+	ctx context.Context,
+	root domain.Namespace,
+	resolver ResolverFunc,
+) ([]domain.Namespace, error) {
+	t := NewTraversal(ctx, resolver)
+
+	if err := t.dfs(root); err != nil {
+		return nil, err
+	}
+
+	return t.order, nil
+}

--- a/internal/engine/deptree/deptree_bench_test.go
+++ b/internal/engine/deptree/deptree_bench_test.go
@@ -1,0 +1,76 @@
+package deptree
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/rabbytesoftware/quiver/internal/domain"
+)
+
+func BenchmarkDeptree_LinearChain10(b *testing.B) {
+	nodes := make([]domain.Namespace, 10)
+	for i := range nodes {
+		nodes[i] = domain.Namespace(fmt.Sprintf("github.com/owner/node%d", i))
+	}
+	graph := make(map[domain.Namespace][]domain.Namespace)
+	for i := 0; i < len(nodes)-1; i++ {
+		graph[nodes[i]] = []domain.Namespace{nodes[i+1]}
+	}
+	resolver := buildResolver(graph)
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = Deptree(
+			ctx,
+			nodes[0],
+			resolver,
+		)
+	}
+}
+
+func BenchmarkDeptree_DiamondDependency(b *testing.B) {
+	a := domain.Namespace("github.com/owner/a")
+	bNode := domain.Namespace("github.com/owner/b")
+	c := domain.Namespace("github.com/owner/c")
+	d := domain.Namespace("github.com/owner/d")
+	graph := map[domain.Namespace][]domain.Namespace{
+		a:     {bNode, c},
+		bNode: {d},
+		c:     {d},
+	}
+	resolver := buildResolver(graph)
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = Deptree(
+			ctx,
+			a,
+			resolver,
+		)
+	}
+}
+
+func BenchmarkDeptree_Wide50Deps(b *testing.B) {
+	root := domain.Namespace("github.com/owner/root")
+	deps := make([]domain.Namespace, 50)
+	for i := range deps {
+		deps[i] = domain.Namespace(fmt.Sprintf("github.com/owner/dep%d", i))
+	}
+	graph := map[domain.Namespace][]domain.Namespace{
+		root: deps,
+	}
+	resolver := buildResolver(graph)
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = Deptree(
+			ctx,
+			root,
+			resolver,
+		)
+	}
+}

--- a/internal/engine/deptree/deptree_test.go
+++ b/internal/engine/deptree/deptree_test.go
@@ -1,0 +1,295 @@
+package deptree
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func ns(
+	label string,
+) domain.Namespace {
+	return domain.Namespace(fmt.Sprintf("github.com/owner/%s", label))
+}
+
+func buildResolver(
+	graph map[domain.Namespace][]domain.Namespace,
+) ResolverFunc {
+	return func(_ context.Context, n domain.Namespace) ([]domain.Namespace, error) {
+		deps, ok := graph[n]
+		if !ok {
+			return []domain.Namespace{}, nil
+		}
+		return deps, nil
+	}
+}
+
+func TestDeptree(t *testing.T) {
+	result, err := Deptree(
+		context.Background(),
+		ns("a"),
+		buildResolver(nil),
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, []domain.Namespace{ns("a")}, result)
+}
+
+func TestDeptree_LinearChain(t *testing.T) {
+	graph := map[domain.Namespace][]domain.Namespace{
+		ns("a"): {ns("b")},
+		ns("b"): {ns("c")},
+		ns("c"): {ns("d")},
+	}
+
+	result, err := Deptree(
+		context.Background(),
+		ns("a"),
+		buildResolver(graph),
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, []domain.Namespace{ns("d"), ns("c"), ns("b"), ns("a")}, result)
+}
+
+func TestDeptree_DiamondDependency(t *testing.T) {
+	graph := map[domain.Namespace][]domain.Namespace{
+		ns("a"): {ns("b"), ns("c")},
+		ns("b"): {ns("d")},
+		ns("c"): {ns("d")},
+	}
+
+	result, err := Deptree(
+		context.Background(),
+		ns("a"),
+		buildResolver(graph),
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, ns("a"), result[len(result)-1])
+
+	count := 0
+	for _, n := range result {
+		if n == ns("d") {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count)
+	assert.Len(t, result, 4)
+}
+
+func TestDeptree_WideDependencies(t *testing.T) {
+	deps := make([]domain.Namespace, 10)
+	for i := range deps {
+		deps[i] = domain.Namespace(fmt.Sprintf("github.com/owner/dep%d", i))
+	}
+	graph := map[domain.Namespace][]domain.Namespace{
+		ns("root"): deps,
+	}
+
+	result, err := Deptree(
+		context.Background(),
+		ns("root"),
+		buildResolver(graph),
+	)
+
+	require.NoError(t, err)
+	assert.Len(t, result, 11)
+	assert.Equal(t, ns("root"), result[len(result)-1])
+}
+
+func TestDeptree_DeepTransitive(t *testing.T) {
+	graph := map[domain.Namespace][]domain.Namespace{
+		ns("a"): {ns("b")},
+		ns("b"): {ns("c")},
+		ns("c"): {ns("d")},
+		ns("d"): {ns("e")},
+	}
+
+	result, err := Deptree(
+		context.Background(),
+		ns("a"),
+		buildResolver(graph),
+	)
+
+	require.NoError(t, err)
+	require.Len(t, result, 5)
+	assert.Equal(t, []domain.Namespace{ns("e"), ns("d"), ns("c"), ns("b"), ns("a")}, result)
+}
+
+func TestDeptree_CyclicDependency(t *testing.T) {
+	graph := map[domain.Namespace][]domain.Namespace{
+		ns("a"): {ns("b")},
+		ns("b"): {ns("c")},
+		ns("c"): {ns("a")},
+	}
+
+	_, err := Deptree(
+		context.Background(),
+		ns("a"),
+		buildResolver(graph),
+	)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrCyclicDependency)
+
+	var cycleErr *CycleError
+	require.ErrorAs(t, err, &cycleErr)
+	assert.Equal(t, ns("a"), cycleErr.Path[0])
+	assert.Equal(t, ns("a"), cycleErr.Path[len(cycleErr.Path)-1])
+	assert.Contains(t, err.Error(), "cyclic dependency detected")
+}
+
+func TestDeptree_SelfDependency(t *testing.T) {
+	graph := map[domain.Namespace][]domain.Namespace{
+		ns("a"): {ns("a")},
+	}
+
+	_, err := Deptree(
+		context.Background(),
+		ns("a"),
+		buildResolver(graph),
+	)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrCyclicDependency)
+
+	var cycleErr *CycleError
+	require.ErrorAs(t, err, &cycleErr)
+	assert.Equal(t, []domain.Namespace{ns("a"), ns("a")}, cycleErr.Path)
+}
+
+func TestDeptree_ResolverError(t *testing.T) {
+	sentinel := errors.New("manifest fetch failed")
+	resolver := func(_ context.Context, n domain.Namespace) ([]domain.Namespace, error) {
+		if n == ns("b") {
+			return nil, sentinel
+		}
+		return []domain.Namespace{ns("b")}, nil
+	}
+
+	_, err := Deptree(
+		context.Background(),
+		ns("a"),
+		resolver,
+	)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sentinel)
+}
+
+func TestDeptree_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	graph := map[domain.Namespace][]domain.Namespace{
+		ns("a"): {ns("b")},
+	}
+
+	_, err := Deptree(
+		ctx,
+		ns("a"),
+		buildResolver(graph),
+	)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestDeptree_ContextDeadlineExceeded(t *testing.T) {
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	graph := map[domain.Namespace][]domain.Namespace{
+		ns("a"): {ns("b")},
+	}
+
+	_, err := Deptree(
+		ctx,
+		ns("a"),
+		buildResolver(graph),
+	)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestDeptree_DeterministicOrder(t *testing.T) {
+	graph := map[domain.Namespace][]domain.Namespace{
+		ns("a"): {ns("b"), ns("c")},
+		ns("b"): {ns("d")},
+		ns("c"): {ns("d")},
+	}
+	resolver := buildResolver(graph)
+
+	result1, err1 := Deptree(context.Background(), ns("a"), resolver)
+	result2, err2 := Deptree(context.Background(), ns("a"), resolver)
+
+	require.NoError(t, err1)
+	require.NoError(t, err2)
+	assert.Equal(t, result1, result2)
+}
+
+func TestDeptree_RootAlwaysLast(t *testing.T) {
+	tests := []struct {
+		name  string
+		root  domain.Namespace
+		graph map[domain.Namespace][]domain.Namespace
+	}{
+		{
+			name:  "no deps",
+			root:  ns("a"),
+			graph: nil,
+		},
+		{
+			name:  "linear chain",
+			root:  ns("a"),
+			graph: map[domain.Namespace][]domain.Namespace{ns("a"): {ns("b")}, ns("b"): {ns("c")}},
+		},
+		{
+			name: "diamond",
+			root: ns("a"),
+			graph: map[domain.Namespace][]domain.Namespace{
+				ns("a"): {ns("b"), ns("c")},
+				ns("b"): {ns("d")},
+				ns("c"): {ns("d")},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := Deptree(
+				context.Background(),
+				tt.root,
+				buildResolver(tt.graph),
+			)
+
+			require.NoError(t, err)
+			require.NotEmpty(t, result)
+			assert.Equal(t, tt.root, result[len(result)-1])
+		})
+	}
+}
+
+func TestCycleError_Error(t *testing.T) {
+	err := &CycleError{Path: []domain.Namespace{ns("a"), ns("b"), ns("a")}}
+
+	msg := err.Error()
+
+	assert.Contains(t, msg, "cyclic dependency detected")
+	assert.Contains(t, msg, "github.com/owner/a")
+	assert.Contains(t, msg, "->")
+}
+
+func TestCycleError_Unwrap(t *testing.T) {
+	err := &CycleError{Path: []domain.Namespace{ns("a"), ns("a")}}
+
+	assert.ErrorIs(t, err, ErrCyclicDependency)
+}

--- a/internal/engine/deptree/errors.go
+++ b/internal/engine/deptree/errors.go
@@ -1,0 +1,27 @@
+package deptree
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/rabbytesoftware/quiver/internal/domain"
+)
+
+var ErrCyclicDependency = errors.New("deptree: cyclic dependency detected")
+
+type CycleError struct {
+	Path []domain.Namespace
+}
+
+func (e *CycleError) Error() string {
+	parts := make([]string, len(e.Path))
+	for i, ns := range e.Path {
+		parts[i] = ns.String()
+	}
+	return fmt.Sprintf("deptree: cyclic dependency detected: %s", strings.Join(parts, " -> "))
+}
+
+func (e *CycleError) Unwrap() error {
+	return ErrCyclicDependency
+}

--- a/internal/engine/deptree/node_state.go
+++ b/internal/engine/deptree/node_state.go
@@ -1,0 +1,9 @@
+package deptree
+
+type nodeState uint8
+
+const (
+	unvisited  nodeState = iota
+	inProgress nodeState = iota
+	done       nodeState = iota
+)

--- a/internal/engine/deptree/traversal.go
+++ b/internal/engine/deptree/traversal.go
@@ -1,0 +1,82 @@
+package deptree
+
+import (
+	"context"
+
+	"github.com/rabbytesoftware/quiver/internal/domain"
+)
+
+type traversal struct {
+	ctx      context.Context
+	resolver ResolverFunc
+	state    map[domain.Namespace]nodeState
+	stack    []domain.Namespace
+	order    []domain.Namespace
+}
+
+func NewTraversal(
+	ctx context.Context,
+	resolver ResolverFunc,
+) traversal {
+	return traversal{
+		ctx:      ctx,
+		resolver: resolver,
+		state:    make(map[domain.Namespace]nodeState, 16),
+		stack:    make([]domain.Namespace, 0, 16),
+		order:    make([]domain.Namespace, 0, 16),
+	}
+}
+
+func (t *traversal) dfs(
+	ns domain.Namespace,
+) error {
+	if t.state[ns] == done {
+		return nil
+	}
+
+	if t.state[ns] == inProgress {
+		return t.buildCycleError(ns)
+	}
+
+	if err := t.ctx.Err(); err != nil {
+		return err
+	}
+
+	t.state[ns] = inProgress
+	t.stack = append(t.stack, ns)
+
+	deps, err := t.resolver(t.ctx, ns)
+	if err != nil {
+		return err
+	}
+
+	for _, dep := range deps {
+		if err := t.dfs(dep); err != nil {
+			return err
+		}
+	}
+
+	t.stack = t.stack[:len(t.stack)-1]
+	t.state[ns] = done
+	t.order = append(t.order, ns)
+
+	return nil
+}
+
+func (t *traversal) buildCycleError(
+	ns domain.Namespace,
+) *CycleError {
+	cycleStart := 0
+	for i, n := range t.stack {
+		if n == ns {
+			cycleStart = i
+			break
+		}
+	}
+
+	path := make([]domain.Namespace, len(t.stack)-cycleStart+1)
+	copy(path, t.stack[cycleStart:])
+	path[len(path)-1] = ns
+
+	return &CycleError{Path: path}
+}

--- a/internal/mocks/deptree.go
+++ b/internal/mocks/deptree.go
@@ -1,0 +1,23 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	"github.com/rabbytesoftware/quiver/internal/engine/deptree"
+)
+
+type MockDepTree struct {
+	ResolveFunc deptree.DepTree
+}
+
+func (m *MockDepTree) Resolve(
+	ctx context.Context,
+	root domain.Namespace,
+	resolver deptree.ResolverFunc,
+) ([]domain.Namespace, error) {
+	if m.ResolveFunc != nil {
+		return m.ResolveFunc(ctx, root, resolver)
+	}
+	return nil, nil
+}


### PR DESCRIPTION
## Summary

- Implements the DepTree engine per `deptree.md` spec (Phase 1B)
- DFS topological sort with 3-color cycle detection via `traversal` struct
- Pure graph module — no I/O, no Asynx knowledge, no manifest knowledge
- `deptree.Deptree()` as the single package-level entry point (singleton function pattern)
- `internal/mocks/deptree.go` for app layer test injection

## Test plan

- [x] 100% statement coverage across all files
- [x] All spec edge cases covered: linear chain, diamond, wide deps, cycle, self-dependency, resolver error, context cancellation, deadline exceeded
- [x] Benchmarks: `BenchmarkDeptree_LinearChain10`, `BenchmarkDeptree_DiamondDependency`, `BenchmarkDeptree_Wide50Deps`
- [x] Race detector clean (`go test -race`)
- [x] Full project test suite passes (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)