### PR TITLE
feat(app): implement Arrow and Quiver service layers with CQRS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,5 +73,3 @@ temp/
 **/db/
 
 coverage/
-
-quiver

--- a/internal/app/arrow/arrow.go
+++ b/internal/app/arrow/arrow.go
@@ -1,0 +1,306 @@
+package arrow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/char2cs/asynx"
+	asynxModels "github.com/char2cs/asynx/models"
+	arrowcmds "github.com/rabbytesoftware/quiver/internal/app/arrow/commands"
+	arrowstore "github.com/rabbytesoftware/quiver/internal/app/arrow/store"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	domainRuntime "github.com/rabbytesoftware/quiver/internal/domain/runtime"
+	"github.com/rabbytesoftware/quiver/internal/engine/deptree"
+	"github.com/rabbytesoftware/quiver/internal/engine/manifold"
+	"github.com/rabbytesoftware/quiver/internal/engine/netbridge"
+	"github.com/rabbytesoftware/quiver/internal/engine/vault"
+	"github.com/rabbytesoftware/quiver/internal/engine/wizard"
+)
+
+// ArrowService manages arrow lifecycle: registration, manifest updates, installation, and execution.
+type ArrowService interface {
+	Add(ctx context.Context, ns domain.Namespace) error
+	Update(ctx context.Context, ns domain.Namespace) error
+	Remove(ctx context.Context, ns domain.Namespace) error
+	List(ctx context.Context) ([]ArrowListDTO, error)
+	GetDetail(ctx context.Context, ns domain.Namespace) (*ArrowDetailDTO, error)
+	Install(ctx context.Context, ns domain.Namespace, userVars map[string]string) error
+	Uninstall(ctx context.Context, ns domain.Namespace, userVars map[string]string) error
+	BeginExecution(ctx context.Context, ns domain.Namespace, method string, userVars map[string]string) error
+	Stop(ctx context.Context, ns domain.Namespace) error
+}
+
+type arrowService struct {
+	asynxArrow   asynx.Asynx[domain.Arrow]
+	asynxRuntime asynx.Asynx[domainRuntime.ArrowRuntime]
+
+	catalog   arrowstore.ArrowCatalog
+	vault     vault.Vault
+	manifold  manifold.Manifold
+	deptree   deptree.DepTree
+	netbridge netbridge.Netbridge
+	wizard    wizard.Wizard
+	os        string
+}
+
+func (svc *arrowService) Add(ctx context.Context, ns domain.Namespace) error {
+	if ns.Validate() != nil {
+		return fmt.Errorf("add arrow: %w", ErrInvalidNamespace)
+	}
+
+	manifest, _, err := svc.resolveManifest(ctx, ns)
+	if err != nil {
+		return fmt.Errorf("add arrow: %w", ErrFetchFailed)
+	}
+
+	if err := svc.asynxArrow.Send(ctx, arrowcmds.AddArrow{
+		Namespace: ns,
+		Manifest:  *manifest,
+	}); err != nil {
+		return fmt.Errorf("add arrow: %w", err)
+	}
+
+	return nil
+}
+
+func (svc *arrowService) Update(ctx context.Context, ns domain.Namespace) error {
+	current, err := svc.asynxArrow.Get(ctx, ns.String())
+	if err != nil {
+		if errors.Is(err, asynxModels.ErrNotFound) {
+			return fmt.Errorf("update arrow: %w", ErrNotFound)
+		}
+		return fmt.Errorf("update arrow: %w", err)
+	}
+
+	if current.Removed {
+		return fmt.Errorf("update arrow: %w", ErrAlreadyRemoved)
+	}
+
+	runtime, err := svc.asynxRuntime.Get(ctx, ns.String())
+	if err != nil && !errors.Is(err, asynxModels.ErrNotFound) {
+		return fmt.Errorf("update arrow: %w", err)
+	}
+
+	if runtime.Namespace != "" && runtime.State != domain.ArrowStateReady {
+		return fmt.Errorf("update arrow: %w", ErrStateViolation)
+	}
+
+	manifest, err := svc.manifold.ResolveArrow(ctx, ns)
+	if err != nil {
+		return fmt.Errorf("update arrow: %w", ErrFetchFailed)
+	}
+
+	if _, err := svc.vault.PutArrow(ctx, ns, manifest, nil); err != nil {
+		return fmt.Errorf("update arrow: %w", err)
+	}
+
+	if err := svc.asynxArrow.Send(ctx, arrowcmds.UpdateArrowManifest{
+		Namespace: ns,
+		Manifest:  *manifest,
+	}); err != nil {
+		return fmt.Errorf("update arrow: %w", err)
+	}
+
+	return nil
+}
+
+func (svc *arrowService) Remove(ctx context.Context, ns domain.Namespace) error {
+	current, err := svc.asynxArrow.Get(ctx, ns.String())
+	if err != nil {
+		if errors.Is(err, asynxModels.ErrNotFound) {
+			return fmt.Errorf("remove arrow: %w", ErrNotFound)
+		}
+		return fmt.Errorf("remove arrow: %w", err)
+	}
+
+	if current.Removed {
+		return fmt.Errorf("remove arrow: %w", ErrAlreadyRemoved)
+	}
+
+	runtime, err := svc.asynxRuntime.Get(ctx, ns.String())
+	if err != nil && !errors.Is(err, asynxModels.ErrNotFound) {
+		return fmt.Errorf("remove arrow: %w", err)
+	}
+
+	if runtime.Namespace != "" {
+		state := runtime.State
+		if state != domain.ArrowStateAbsent && state != domain.ArrowStateRemoved && state != "" {
+			return fmt.Errorf("remove arrow: %w", ErrStateViolation)
+		}
+	}
+
+	if err := svc.asynxArrow.Send(ctx, arrowcmds.RemoveArrow{Namespace: ns}); err != nil {
+		return fmt.Errorf("remove arrow: %w", err)
+	}
+
+	_ = svc.vault.DeleteArrow(ctx, ns) // best-effort: removal proceeds even if vault cleanup fails
+
+	return nil
+}
+
+func (s *arrowService) List(ctx context.Context) ([]ArrowListDTO, error) {
+	arrows, err := s.catalog.List()
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]ArrowListDTO, 0, len(arrows))
+	for _, arrow := range arrows {
+		if arrow.Removed {
+			continue
+		}
+
+		state := domain.ArrowStateAbsent
+		runtime, runtimeErr := s.asynxRuntime.Get(ctx, arrow.Namespace.String())
+		if runtimeErr == nil && runtime.State != "" {
+			state = runtime.State
+		} else if runtimeErr != nil && !errors.Is(runtimeErr, asynxModels.ErrNotFound) {
+			return nil, runtimeErr
+		}
+
+		result = append(result, ArrowListDTO{
+			Namespace:   arrow.Namespace,
+			Name:        arrow.Manifest.Name,
+			Version:     arrow.Manifest.Version,
+			Description: arrow.Manifest.Description,
+			State:       state,
+			Tags:        arrow.Manifest.Tags,
+			Removed:     arrow.Removed,
+		})
+	}
+
+	return result, nil
+}
+
+func (s *arrowService) GetDetail(ctx context.Context, ns domain.Namespace) (*ArrowDetailDTO, error) {
+	arrow, err := s.catalog.Get(ns)
+	if err != nil {
+		return nil, err
+	}
+	if arrow == nil {
+		return nil, fmt.Errorf("get detail: %w", ErrNotFound)
+	}
+
+	state := domain.ArrowStateAbsent
+	var activeRun *domainRuntime.RunRecord
+	var lastReturn *domainRuntime.Return
+
+	runtime, runtimeErr := s.asynxRuntime.Get(ctx, ns.String())
+	if runtimeErr == nil && runtime.State != "" {
+		state = runtime.State
+	} else if runtimeErr != nil && !errors.Is(runtimeErr, asynxModels.ErrNotFound) {
+		return nil, runtimeErr
+	}
+
+	if !errors.Is(runtimeErr, asynxModels.ErrNotFound) && runtimeErr == nil {
+		activeRun = runtime.ActiveRun
+		lastReturn = runtime.LastReturn
+	}
+
+	var indirectDeps []domain.Namespace
+	entry, _, vaultErr := s.vault.GetArrow(ctx, ns)
+	if vaultErr == nil && entry != nil {
+		indirectDeps = entry.IndirectDependencies
+	}
+
+	return &ArrowDetailDTO{
+		Namespace:            arrow.Namespace,
+		Manifest:             arrow.Manifest,
+		State:                state,
+		Removed:              arrow.Removed,
+		ActiveRun:            activeRun,
+		LastReturn:           lastReturn,
+		IndirectDependencies: indirectDeps,
+	}, nil
+}
+
+func (svc *arrowService) Install(
+	ctx context.Context,
+	ns domain.Namespace,
+	userVars map[string]string,
+) error {
+	arrow, err := svc.asynxArrow.Get(ctx, ns.String())
+	if errors.Is(err, asynxModels.ErrNotFound) || arrow.Namespace == "" {
+		return fmt.Errorf("install: %w", ErrNotFound)
+	}
+	if err != nil {
+		return err
+	}
+
+	rt, err := svc.asynxRuntime.Get(ctx, ns.String())
+	if err != nil && !errors.Is(err, asynxModels.ErrNotFound) {
+		return err
+	}
+	if rt.Namespace != "" && rt.State != domain.ArrowStateAbsent {
+		return fmt.Errorf("install: %w", ErrStateViolation)
+	}
+
+	go svc.runInstall(ctx, ns, userVars)
+	return nil
+}
+
+func (svc *arrowService) Uninstall(
+	ctx context.Context,
+	ns domain.Namespace,
+	userVars map[string]string,
+) error {
+	rt, err := svc.asynxRuntime.Get(ctx, ns.String())
+	if errors.Is(err, asynxModels.ErrNotFound) || rt.Namespace == "" || rt.State != domain.ArrowStateReady {
+		return fmt.Errorf("uninstall: %w", ErrStateViolation)
+	}
+
+	hasDeps, err := svc.hasDependents(ctx, ns, "")
+	if err != nil {
+		return err
+	}
+	if hasDeps {
+		return fmt.Errorf("uninstall: %w", ErrDependentsExist)
+	}
+
+	go svc.runUninstall(ctx, ns, userVars)
+	return nil
+}
+
+func (svc *arrowService) BeginExecution(
+	ctx context.Context,
+	ns domain.Namespace,
+	method string,
+	userVars map[string]string,
+) error {
+	req, reporter, err := svc.beginExecution(ctx, ns, method, userVars)
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		execErr := svc.wizard.Execute(context.Background(), *req, reporter)
+		outcome := svc.mapOutcome(execErr)
+		_ = svc.asynxRuntime.Send(context.Background(), arrowcmds.EndExecution{Namespace: ns, Outcome: outcome})
+		if execErr != nil {
+			svc.handleExecutionError(context.Background(), ns, method, execErr)
+		}
+	}()
+
+	return nil
+}
+
+func (svc *arrowService) Stop(ctx context.Context, ns domain.Namespace) error {
+	runtime, err := svc.asynxRuntime.Get(ctx, ns.String())
+	if err != nil {
+		if errors.Is(err, asynxModels.ErrNotFound) {
+			return fmt.Errorf("stop: %w", ErrNotFound)
+		}
+		return fmt.Errorf("stop: %w", err)
+	}
+
+	if runtime.State != domain.ArrowStateRunning {
+		return fmt.Errorf("stop: %w", ErrStateViolation)
+	}
+
+	if err := svc.asynxRuntime.Send(ctx, arrowcmds.MarkStopping{Namespace: ns}); err != nil {
+		return fmt.Errorf("stop: %w", err)
+	}
+
+	return nil
+}

--- a/internal/app/arrow/arrow_test.go
+++ b/internal/app/arrow/arrow_test.go
@@ -1,0 +1,456 @@
+package arrow
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	sqlite "github.com/rabbytesoftware/quiver/internal/adapter/eventstore/sqlite"
+	arrowcmds "github.com/rabbytesoftware/quiver/internal/app/arrow/commands"
+	arrowstore "github.com/rabbytesoftware/quiver/internal/app/arrow/store"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	domainRuntime "github.com/rabbytesoftware/quiver/internal/domain/runtime"
+	"github.com/rabbytesoftware/quiver/internal/engine/vault"
+	"github.com/rabbytesoftware/quiver/internal/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeTestManifest(name string) *domain.ArrowManifest {
+	return &domain.ArrowManifest{
+		Name:        name,
+		Version:     "1.0.0",
+		Description: "A test arrow",
+		Tags:        []string{"test"},
+	}
+}
+
+func makeArrowServiceWithMocks(v vault.Vault, m *mocks.Manifold) *arrowService {
+	return &arrowService{vault: v, manifold: m}
+}
+
+func testArrowService(t *testing.T, v vault.Vault, m *mocks.Manifold) *arrowService {
+	t.Helper()
+	arrowES, err := sqlite.NewEventStore(":memory:")
+	require.NoError(t, err)
+	runtimeES, err := sqlite.NewEventStore(":memory:")
+	require.NoError(t, err)
+	axArrow, err := newAsynxArrow(arrowES)
+	require.NoError(t, err)
+	axRuntime, err := newAsynxRuntime(runtimeES)
+	require.NoError(t, err)
+	catalog, err := arrowstore.NewArrowCatalogFromPath(":memory:")
+	require.NoError(t, err)
+	return &arrowService{
+		asynxArrow:   axArrow,
+		asynxRuntime: axRuntime,
+		catalog:      catalog,
+		vault:        v,
+		manifold:     m,
+	}
+}
+
+func addArrowForTest(t *testing.T, svc *arrowService, ns domain.Namespace, manifest *domain.ArrowManifest) {
+	t.Helper()
+	require.NoError(t, svc.catalog.Save(domain.Arrow{Namespace: ns, Manifest: *manifest}))
+	require.NoError(t, svc.asynxArrow.Send(context.Background(), arrowcmds.AddArrow{
+		Namespace: ns,
+		Manifest:  *manifest,
+	}))
+	svc.asynxArrow.WaitPublish()
+}
+
+// --- Add ---
+
+func TestAdd_InvalidNamespace_ReturnsErrInvalidNamespace(t *testing.T) {
+	svc := testArrowService(t, &mocks.Vault{}, &mocks.Manifold{})
+
+	err := svc.Add(context.Background(), "bad-namespace")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidNamespace)
+}
+
+func TestAdd_ManifoldFails_ReturnsErrFetchFailed(t *testing.T) {
+	mv := &mocks.Vault{GetArrowErr: vault.ErrNotCached}
+	mm := &mocks.Manifold{ResolveArrowErr: errors.New("network error")}
+	svc := testArrowService(t, mv, mm)
+
+	err := svc.Add(context.Background(), "github.com/org/repo")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrFetchFailed)
+}
+
+func TestAdd_Success_ArrowSentToAsynx(t *testing.T) {
+	manifest := makeTestManifest("MyArrow")
+	mv := &mocks.Vault{
+		GetArrowErr:  vault.ErrNotCached,
+		PutArrowPath: "/tmp/test",
+	}
+	mm := &mocks.Manifold{ResolveArrowManifest: manifest}
+	svc := testArrowService(t, mv, mm)
+
+	err := svc.Add(context.Background(), "github.com/org/repo")
+	require.NoError(t, err)
+
+	svc.asynxArrow.WaitPublish()
+
+	got, err := svc.asynxArrow.Get(context.Background(), "github.com/org/repo")
+	require.NoError(t, err)
+	assert.Equal(t, domain.Namespace("github.com/org/repo"), got.Namespace)
+	assert.False(t, got.Removed)
+}
+
+func TestAdd_AlreadyExists_ReturnsError(t *testing.T) {
+	manifest := makeTestManifest("MyArrow")
+	mv := &mocks.Vault{
+		GetArrowErr:  vault.ErrNotCached,
+		PutArrowPath: "/tmp/test",
+	}
+	mm := &mocks.Manifold{ResolveArrowManifest: manifest}
+	svc := testArrowService(t, mv, mm)
+
+	require.NoError(t, svc.Add(context.Background(), "github.com/org/repo"))
+	svc.asynxArrow.WaitPublish()
+
+	err := svc.Add(context.Background(), "github.com/org/repo")
+	require.Error(t, err)
+}
+
+// --- Update ---
+
+func TestUpdate_NotFound_ReturnsErrNotFound(t *testing.T) {
+	mv := &mocks.Vault{GetArrowErr: vault.ErrNotCached}
+	mm := &mocks.Manifold{}
+	svc := testArrowService(t, mv, mm)
+
+	err := svc.Update(context.Background(), "github.com/org/repo")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestUpdate_AlreadyRemoved_ReturnsErrAlreadyRemoved(t *testing.T) {
+	manifest := makeTestManifest("MyArrow")
+	mv := &mocks.Vault{
+		GetArrowErr:  vault.ErrNotCached,
+		PutArrowPath: "/tmp/test",
+	}
+	mm := &mocks.Manifold{ResolveArrowManifest: manifest}
+	svc := testArrowService(t, mv, mm)
+
+	addArrowForTest(t, svc, "github.com/org/repo", manifest)
+
+	// Mark as removed via command
+	require.NoError(t, svc.asynxArrow.Send(context.Background(), arrowcmds.RemoveArrow{Namespace: "github.com/org/repo"}))
+	svc.asynxArrow.WaitPublish()
+
+	err := svc.Update(context.Background(), "github.com/org/repo")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrAlreadyRemoved)
+}
+
+func TestUpdate_ManifoldFails_ReturnsErrFetchFailed(t *testing.T) {
+	manifest := makeTestManifest("MyArrow")
+	mv := &mocks.Vault{
+		GetArrowErr:  vault.ErrNotCached,
+		PutArrowPath: "/tmp/test",
+	}
+	mm := &mocks.Manifold{ResolveArrowManifest: manifest}
+	svc := testArrowService(t, mv, mm)
+
+	addArrowForTest(t, svc, "github.com/org/repo", manifest)
+
+	// Now make manifold fail
+	mm.ResolveArrowErr = errors.New("network error")
+	mm.ResolveArrowManifest = nil
+
+	err := svc.Update(context.Background(), "github.com/org/repo")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrFetchFailed)
+}
+
+func TestUpdate_Success_UpdatesArrow(t *testing.T) {
+	manifest := makeTestManifest("MyArrow")
+	updatedManifest := makeTestManifest("UpdatedArrow")
+	mv := &mocks.Vault{
+		GetArrowErr:  vault.ErrNotCached,
+		PutArrowPath: "/tmp/test",
+	}
+	mm := &mocks.Manifold{ResolveArrowManifest: manifest}
+	svc := testArrowService(t, mv, mm)
+
+	addArrowForTest(t, svc, "github.com/org/repo", manifest)
+
+	mm.ResolveArrowManifest = updatedManifest
+	err := svc.Update(context.Background(), "github.com/org/repo")
+	require.NoError(t, err)
+	svc.asynxArrow.WaitPublish()
+
+	got, err := svc.asynxArrow.Get(context.Background(), "github.com/org/repo")
+	require.NoError(t, err)
+	assert.Equal(t, "UpdatedArrow", got.Manifest.Name)
+}
+
+// --- Remove ---
+
+func TestRemove_NotFound_ReturnsErrNotFound(t *testing.T) {
+	mv := &mocks.Vault{GetArrowErr: vault.ErrNotCached}
+	mm := &mocks.Manifold{}
+	svc := testArrowService(t, mv, mm)
+
+	err := svc.Remove(context.Background(), "github.com/org/repo")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestRemove_AlreadyRemoved_ReturnsErrAlreadyRemoved(t *testing.T) {
+	manifest := makeTestManifest("MyArrow")
+	mv := &mocks.Vault{
+		GetArrowErr:  vault.ErrNotCached,
+		PutArrowPath: "/tmp/test",
+	}
+	mm := &mocks.Manifold{ResolveArrowManifest: manifest}
+	svc := testArrowService(t, mv, mm)
+
+	addArrowForTest(t, svc, "github.com/org/repo", manifest)
+	require.NoError(t, svc.asynxArrow.Send(context.Background(), arrowcmds.RemoveArrow{Namespace: "github.com/org/repo"}))
+	svc.asynxArrow.WaitPublish()
+
+	err := svc.Remove(context.Background(), "github.com/org/repo")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrAlreadyRemoved)
+}
+
+func TestRemove_Success_MarksArrowRemoved(t *testing.T) {
+	manifest := makeTestManifest("MyArrow")
+	mv := &mocks.Vault{
+		GetArrowErr:  vault.ErrNotCached,
+		PutArrowPath: "/tmp/test",
+	}
+	mm := &mocks.Manifold{ResolveArrowManifest: manifest}
+	svc := testArrowService(t, mv, mm)
+
+	addArrowForTest(t, svc, "github.com/org/repo", manifest)
+
+	err := svc.Remove(context.Background(), "github.com/org/repo")
+	require.NoError(t, err)
+	svc.asynxArrow.WaitPublish()
+
+	got, err := svc.asynxArrow.Get(context.Background(), "github.com/org/repo")
+	require.NoError(t, err)
+	assert.True(t, got.Removed)
+}
+
+func TestRemove_ActiveRuntime_ReturnsErrStateViolation(t *testing.T) {
+	manifest := makeTestManifest("MyArrow")
+	mv := &mocks.Vault{
+		GetArrowErr:  vault.ErrNotCached,
+		PutArrowPath: "/tmp/test",
+	}
+	mm := &mocks.Manifold{ResolveArrowManifest: manifest}
+	svc := testArrowService(t, mv, mm)
+
+	addArrowForTest(t, svc, "github.com/org/repo", manifest)
+
+	// Simulate a running runtime state
+	require.NoError(t, svc.asynxRuntime.Send(context.Background(), mocks.RuntimeCmd{
+		NS:    "github.com/org/repo",
+		State: domain.ArrowStateRunning,
+	}))
+	svc.asynxRuntime.WaitPublish()
+
+	err := svc.Remove(context.Background(), "github.com/org/repo")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrStateViolation)
+}
+
+// --- List ---
+
+func TestList_EmptyCatalog_ReturnsEmpty(t *testing.T) {
+	svc := testArrowService(t, &mocks.Vault{}, &mocks.Manifold{})
+
+	result, err := svc.List(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestList_FiltersRemovedArrows(t *testing.T) {
+	manifest := makeTestManifest("Arrow")
+	svc := testArrowService(t, &mocks.Vault{}, &mocks.Manifold{})
+
+	require.NoError(t, svc.catalog.Save(domain.Arrow{
+		Namespace: "github.com/org/active",
+		Manifest:  *manifest,
+		Removed:   false,
+	}))
+	require.NoError(t, svc.catalog.Save(domain.Arrow{
+		Namespace: "github.com/org/removed",
+		Manifest:  *manifest,
+		Removed:   true,
+	}))
+
+	result, err := svc.List(context.Background())
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, domain.Namespace("github.com/org/active"), result[0].Namespace)
+}
+
+func TestList_IncludesRuntimeState(t *testing.T) {
+	manifest := makeTestManifest("Arrow")
+	svc := testArrowService(t, &mocks.Vault{}, &mocks.Manifold{})
+
+	ns := domain.Namespace("github.com/org/repo")
+	require.NoError(t, svc.catalog.Save(domain.Arrow{
+		Namespace: ns,
+		Manifest:  *manifest,
+	}))
+
+	err := svc.asynxRuntime.Send(context.Background(), mocks.RuntimeCmd{
+		NS:    ns,
+		State: domain.ArrowStateReady,
+	})
+	require.NoError(t, err)
+	svc.asynxRuntime.WaitPublish()
+
+	result, err := svc.List(context.Background())
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, domain.ArrowStateReady, result[0].State)
+}
+
+func TestList_NoRuntime_ReturnsAbsentState(t *testing.T) {
+	manifest := makeTestManifest("Arrow")
+	svc := testArrowService(t, &mocks.Vault{}, &mocks.Manifold{})
+
+	require.NoError(t, svc.catalog.Save(domain.Arrow{
+		Namespace: "github.com/org/repo",
+		Manifest:  *manifest,
+	}))
+
+	result, err := svc.List(context.Background())
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, domain.ArrowStateAbsent, result[0].State)
+}
+
+// --- GetDetail ---
+
+func TestGetDetail_NotFound_ReturnsError(t *testing.T) {
+	svc := testArrowService(t, &mocks.Vault{}, &mocks.Manifold{})
+
+	_, err := svc.GetDetail(context.Background(), "github.com/org/nonexistent")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestGetDetail_NoRuntime_ReturnsAbsentState(t *testing.T) {
+	manifest := makeTestManifest("Arrow")
+	svc := testArrowService(t, &mocks.Vault{}, &mocks.Manifold{})
+
+	ns := domain.Namespace("github.com/org/repo")
+	require.NoError(t, svc.catalog.Save(domain.Arrow{
+		Namespace: ns,
+		Manifest:  *manifest,
+	}))
+
+	dto, err := svc.GetDetail(context.Background(), ns)
+	require.NoError(t, err)
+	assert.Equal(t, domain.ArrowStateAbsent, dto.State)
+}
+
+func TestGetDetail_WithRuntime_ReturnsCorrectState(t *testing.T) {
+	manifest := makeTestManifest("Arrow")
+	svc := testArrowService(t, &mocks.Vault{}, &mocks.Manifold{})
+
+	ns := domain.Namespace("github.com/org/repo")
+	require.NoError(t, svc.catalog.Save(domain.Arrow{
+		Namespace: ns,
+		Manifest:  *manifest,
+	}))
+
+	err := svc.asynxRuntime.Send(context.Background(), mocks.RuntimeCmd{
+		NS:    ns,
+		State: domain.ArrowStateReady,
+	})
+	require.NoError(t, err)
+	svc.asynxRuntime.WaitPublish()
+
+	dto, err := svc.GetDetail(context.Background(), ns)
+	require.NoError(t, err)
+	assert.Equal(t, domain.ArrowStateReady, dto.State)
+}
+
+func TestGetDetail_WithIndirectDeps_IncludesDeps(t *testing.T) {
+	manifest := makeTestManifest("Arrow")
+	ns := domain.Namespace("github.com/org/repo")
+	indirectDeps := []domain.Namespace{"github.com/dep/one", "github.com/dep/two"}
+
+	mv := &mocks.Vault{
+		GetArrowEntry: &vault.VaultEntry{
+			Manifest:             manifest,
+			IndirectDependencies: indirectDeps,
+		},
+	}
+	svc := testArrowService(t, mv, &mocks.Manifold{})
+	require.NoError(t, svc.catalog.Save(domain.Arrow{
+		Namespace: ns,
+		Manifest:  *manifest,
+	}))
+
+	dto, err := svc.GetDetail(context.Background(), ns)
+	require.NoError(t, err)
+	assert.Equal(t, indirectDeps, dto.IndirectDependencies)
+}
+
+func TestGetDetail_VaultError_StillReturns(t *testing.T) {
+	manifest := makeTestManifest("Arrow")
+	ns := domain.Namespace("github.com/org/repo")
+
+	mv := &mocks.Vault{
+		GetArrowErr: errors.New("vault unavailable"),
+	}
+	svc := testArrowService(t, mv, &mocks.Manifold{})
+	require.NoError(t, svc.catalog.Save(domain.Arrow{
+		Namespace: ns,
+		Manifest:  *manifest,
+	}))
+
+	dto, err := svc.GetDetail(context.Background(), ns)
+	require.NoError(t, err)
+	assert.Nil(t, dto.IndirectDependencies)
+	assert.Equal(t, ns, dto.Namespace)
+}
+
+func TestGetDetail_WithRuntimeExecution_PopulatesActiveRunAndLastReturn(t *testing.T) {
+	manifest := makeTestManifest("Arrow")
+	svc := testArrowService(t, &mocks.Vault{}, &mocks.Manifold{})
+
+	ns := domain.Namespace("github.com/org/repo")
+	require.NoError(t, svc.catalog.Save(domain.Arrow{
+		Namespace: ns,
+		Manifest:  *manifest,
+	}))
+
+	activeRun := &domainRuntime.RunRecord{
+		Method:    "run",
+		Variables: map[string]string{"key": "value"},
+	}
+	lastReturn := &domainRuntime.Return{
+		Method:  "run",
+		Outcome: domainRuntime.ExecutionOutcomeSuccess,
+	}
+
+	err := svc.asynxRuntime.Send(context.Background(), mocks.RuntimeCmdWithExecution{
+		NS:         ns,
+		State:      domain.ArrowStateReady,
+		ActiveRun:  activeRun,
+		LastReturn: lastReturn,
+	})
+	require.NoError(t, err)
+	svc.asynxRuntime.WaitPublish()
+
+	dto, err := svc.GetDetail(context.Background(), ns)
+	require.NoError(t, err)
+	assert.Equal(t, domain.ArrowStateReady, dto.State)
+	assert.Equal(t, activeRun, dto.ActiveRun)
+	assert.Equal(t, lastReturn, dto.LastReturn)
+}

--- a/internal/app/arrow/asynx.go
+++ b/internal/app/arrow/asynx.go
@@ -1,1 +1,0 @@
-package arrow

--- a/internal/app/arrow/builder.go
+++ b/internal/app/arrow/builder.go
@@ -1,0 +1,170 @@
+package arrow
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/char2cs/asynx"
+	asynxModels "github.com/char2cs/asynx/models"
+	arrowproj "github.com/rabbytesoftware/quiver/internal/app/arrow/projections"
+	arrowstore "github.com/rabbytesoftware/quiver/internal/app/arrow/store"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	domainRuntime "github.com/rabbytesoftware/quiver/internal/domain/runtime"
+	"github.com/rabbytesoftware/quiver/internal/engine/deptree"
+	"github.com/rabbytesoftware/quiver/internal/engine/manifold"
+	"github.com/rabbytesoftware/quiver/internal/engine/netbridge"
+	"github.com/rabbytesoftware/quiver/internal/engine/vault"
+	"github.com/rabbytesoftware/quiver/internal/engine/wizard"
+)
+
+type Builder struct {
+	eventStore        asynxModels.Store
+	runtimeEventStore asynxModels.Store
+	catalog           arrowstore.ArrowCatalog
+	vault             vault.Vault
+	manifold          manifold.Manifold
+	deptree           deptree.DepTree
+	netbridge         netbridge.Netbridge
+	wizard            wizard.Wizard
+	os                string
+}
+
+func NewArrowBuilder() *Builder {
+	return &Builder{}
+}
+
+func (b *Builder) WithEventStore(es asynxModels.Store) *Builder {
+	b.eventStore = es
+	return b
+}
+
+func (b *Builder) WithRuntimeEventStore(es asynxModels.Store) *Builder {
+	b.runtimeEventStore = es
+	return b
+}
+
+func (b *Builder) WithCatalog(c arrowstore.ArrowCatalog) *Builder {
+	b.catalog = c
+	return b
+}
+
+func (b *Builder) WithVault(v vault.Vault) *Builder {
+	b.vault = v
+	return b
+}
+
+func (b *Builder) WithManifold(m manifold.Manifold) *Builder {
+	b.manifold = m
+	return b
+}
+
+func (b *Builder) WithDepTree(dt deptree.DepTree) *Builder {
+	b.deptree = dt
+	return b
+}
+
+func (b *Builder) WithNetbridge(nb netbridge.Netbridge) *Builder {
+	b.netbridge = nb
+	return b
+}
+
+func (b *Builder) WithWizard(w wizard.Wizard) *Builder {
+	b.wizard = w
+	return b
+}
+
+func (b *Builder) WithOS(os string) *Builder {
+	b.os = os
+	return b
+}
+
+// Build constructs and returns an ArrowService
+func (b *Builder) Build(ctx context.Context) (ArrowService, error) {
+	if b.eventStore == nil {
+		return nil, fmt.Errorf("arrow builder: event store is required")
+	}
+
+	axArrow, err := newAsynxArrow(b.eventStore)
+	if err != nil {
+		return nil, err
+	}
+
+	runtimeES := b.runtimeEventStore
+	if runtimeES == nil {
+		runtimeES = b.eventStore
+	}
+
+	axRuntime, err := newAsynxRuntime(runtimeES)
+	if err != nil {
+		return nil, err
+	}
+
+	catalog := b.catalog
+	if catalog == nil {
+		var err error
+		catalog, err = arrowstore.NewArrowCatalog()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	svc := &arrowService{
+		asynxArrow:   axArrow,
+		asynxRuntime: axRuntime,
+		catalog:      catalog,
+		vault:        b.vault,
+		manifold:     b.manifold,
+		deptree:      b.deptree,
+		netbridge:    b.netbridge,
+		wizard:       b.wizard,
+		os:           b.os,
+	}
+
+	_, err = svc.asynxArrow.Subscribe("arrow.added", arrowproj.OnArrowAdded(catalog))
+	if err != nil {
+		return nil, err
+	}
+	_, err = svc.asynxArrow.Subscribe("arrow.updated", arrowproj.OnArrowUpdated(catalog))
+	if err != nil {
+		return nil, err
+	}
+	_, err = svc.asynxArrow.Subscribe("arrow.removed", arrowproj.OnArrowRemoved(catalog))
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = svc.asynxRuntime.Subscribe("runtime.mark_stopping", arrowproj.StopCoordinator(b.wizard))
+	if err != nil {
+		return nil, err
+	}
+
+	return svc, nil
+}
+
+// newAsynxArrow creates and returns a new Asynx instance for Arrow aggregates
+func newAsynxArrow(es asynxModels.Store) (asynx.Asynx[domain.Arrow], error) {
+	if es == nil {
+		return nil, fmt.Errorf("asynx arrow: event store is required")
+	}
+
+	ax, err := asynx.New[domain.Arrow]().
+		WithEventStore(es).
+		WithShardingOpts(asynx.ShardingOpts{Shards: 8, QueueDepth: 1000}).
+		Build()
+
+	return ax, err
+}
+
+// newAsynxRuntime creates and returns a new Asynx instance for ArrowRuntime aggregates
+func newAsynxRuntime(es asynxModels.Store) (asynx.Asynx[domainRuntime.ArrowRuntime], error) {
+	if es == nil {
+		return nil, fmt.Errorf("asynx runtime: event store is required")
+	}
+
+	ax, err := asynx.New[domainRuntime.ArrowRuntime]().
+		WithEventStore(es).
+		WithShardingOpts(asynx.ShardingOpts{Shards: 8, QueueDepth: 1000}).
+		Build()
+
+	return ax, err
+}

--- a/internal/app/arrow/builder_test.go
+++ b/internal/app/arrow/builder_test.go
@@ -1,0 +1,50 @@
+package arrow
+
+import (
+	"context"
+	"testing"
+
+	sqlite "github.com/rabbytesoftware/quiver/internal/adapter/eventstore/sqlite"
+	arrowstore "github.com/rabbytesoftware/quiver/internal/app/arrow/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuilder_Build_SucceedsWithValidEventStore(t *testing.T) {
+	es, err := sqlite.NewEventStore(":memory:")
+	require.NoError(t, err)
+
+	catalog, err := arrowstore.NewArrowCatalogFromPath(":memory:")
+	require.NoError(t, err)
+
+	svc, err := NewArrowBuilder().
+		WithEventStore(es).
+		WithCatalog(catalog).
+		Build(context.Background())
+
+	require.NoError(t, err)
+	assert.NotNil(t, svc)
+}
+
+func TestBuilder_Build_FailsWithNilEventStore(t *testing.T) {
+	svc, err := NewArrowBuilder().Build(context.Background())
+
+	require.Error(t, err)
+	assert.Nil(t, svc)
+}
+
+func TestBuilder_Build_UsesProvidedCatalog(t *testing.T) {
+	es, err := sqlite.NewEventStore(":memory:")
+	require.NoError(t, err)
+
+	catalog, err := arrowstore.NewArrowCatalogFromPath(":memory:")
+	require.NoError(t, err)
+
+	svc, err := NewArrowBuilder().
+		WithEventStore(es).
+		WithCatalog(catalog).
+		Build(context.Background())
+
+	require.NoError(t, err)
+	assert.NotNil(t, svc)
+}

--- a/internal/app/arrow/commands/add.go
+++ b/internal/app/arrow/commands/add.go
@@ -1,1 +1,40 @@
 package commands
+
+import (
+	"fmt"
+
+	asynxModels "github.com/char2cs/asynx/models"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+)
+
+type AddArrow struct {
+	Namespace domain.Namespace
+	Manifest  domain.ArrowManifest
+}
+
+func (c AddArrow) AggregateID() string {
+	return c.Namespace.String()
+}
+
+func (c AddArrow) EventName() string {
+	return "arrow.added"
+}
+
+func (c AddArrow) ShouldSnapshot() bool {
+	return false
+}
+
+func (c AddArrow) Validate(current *domain.Arrow) error {
+	if current != nil && !current.Removed {
+		return fmt.Errorf("add arrow: %w", asynxModels.ErrValidation)
+	}
+	return nil
+}
+
+func (c AddArrow) EmitEvent(_ *domain.Arrow) domain.Arrow {
+	return domain.Arrow{
+		Namespace: c.Namespace,
+		Manifest:  c.Manifest,
+		Removed:   false,
+	}
+}

--- a/internal/app/arrow/commands/add_test.go
+++ b/internal/app/arrow/commands/add_test.go
@@ -1,0 +1,48 @@
+package commands
+
+import (
+	"errors"
+	"testing"
+
+	asynxModels "github.com/char2cs/asynx/models"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddArrow_AggregateID(t *testing.T) {
+	cmd := AddArrow{Namespace: "github.com/org/repo"}
+	assert.Equal(t, "github.com/org/repo", cmd.AggregateID())
+}
+
+func TestAddArrow_EventName(t *testing.T) {
+	assert.Equal(t, "arrow.added", AddArrow{}.EventName())
+}
+
+func TestAddArrow_Validate_NilState_ReturnsNil(t *testing.T) {
+	cmd := AddArrow{Namespace: "github.com/org/repo"}
+	require.NoError(t, cmd.Validate(nil))
+}
+
+func TestAddArrow_Validate_AlreadyExists_ReturnsValidationError(t *testing.T) {
+	cmd := AddArrow{Namespace: "github.com/org/repo"}
+	existing := &domain.Arrow{Namespace: "github.com/org/repo", Removed: false}
+	err := cmd.Validate(existing)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, asynxModels.ErrValidation))
+}
+
+func TestAddArrow_Validate_RemovedArrow_ReturnsNil(t *testing.T) {
+	cmd := AddArrow{Namespace: "github.com/org/repo"}
+	existing := &domain.Arrow{Namespace: "github.com/org/repo", Removed: true}
+	require.NoError(t, cmd.Validate(existing))
+}
+
+func TestAddArrow_EmitEvent_ReturnsArrow(t *testing.T) {
+	manifest := domain.ArrowManifest{Name: "Test", Version: "1.0.0"}
+	cmd := AddArrow{Namespace: "github.com/org/repo", Manifest: manifest}
+	result := cmd.EmitEvent(nil)
+	assert.Equal(t, domain.Namespace("github.com/org/repo"), result.Namespace)
+	assert.Equal(t, manifest, result.Manifest)
+	assert.False(t, result.Removed)
+}

--- a/internal/app/arrow/commands/advance_step.go
+++ b/internal/app/arrow/commands/advance_step.go
@@ -1,1 +1,58 @@
 package commands
+
+import (
+	"fmt"
+
+	asynxModels "github.com/char2cs/asynx/models"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	domainRuntime "github.com/rabbytesoftware/quiver/internal/domain/runtime"
+)
+
+type AdvanceStep struct {
+	Namespace domain.Namespace
+	StepIndex int
+	ToStatus  domainRuntime.StepStatus
+	Error     *string
+}
+
+func (c AdvanceStep) AggregateID() string {
+	return c.Namespace.String()
+}
+
+func (c AdvanceStep) EventName() string {
+	return "runtime.step_advanced"
+}
+
+func (c AdvanceStep) ShouldSnapshot() bool {
+	return false
+}
+
+func (c AdvanceStep) Validate(current *domainRuntime.ArrowRuntime) error {
+	if current == nil || current.Namespace == "" {
+		return fmt.Errorf("advance step: %w", asynxModels.ErrValidation)
+	}
+	if current.ActiveRun == nil {
+		return fmt.Errorf("advance step: %w", asynxModels.ErrValidation)
+	}
+	return nil
+}
+
+func (c AdvanceStep) EmitEvent(current *domainRuntime.ArrowRuntime) domainRuntime.ArrowRuntime {
+	steps := make([]domainRuntime.StepProgress, len(current.ActiveRun.Steps))
+	copy(steps, current.ActiveRun.Steps)
+	steps[c.StepIndex].Status = c.ToStatus
+	steps[c.StepIndex].Error = c.Error
+
+	updatedRun := &domainRuntime.RunRecord{
+		Method:    current.ActiveRun.Method,
+		Steps:     steps,
+		Variables: current.ActiveRun.Variables,
+	}
+
+	return domainRuntime.ArrowRuntime{
+		Namespace:  current.Namespace,
+		State:      current.State,
+		ActiveRun:  updatedRun,
+		LastReturn: current.LastReturn,
+	}
+}

--- a/internal/app/arrow/commands/advance_step_test.go
+++ b/internal/app/arrow/commands/advance_step_test.go
@@ -1,0 +1,58 @@
+package commands
+
+import (
+	"errors"
+	"testing"
+
+	asynxModels "github.com/char2cs/asynx/models"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	domainRuntime "github.com/rabbytesoftware/quiver/internal/domain/runtime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdvanceStep_AggregateID(t *testing.T) {
+	cmd := AdvanceStep{Namespace: "github.com/org/repo"}
+	assert.Equal(t, "github.com/org/repo", cmd.AggregateID())
+}
+
+func TestAdvanceStep_EventName(t *testing.T) {
+	assert.Equal(t, "runtime.step_advanced", AdvanceStep{}.EventName())
+}
+
+func TestAdvanceStep_Validate_NilRuntime_ReturnsError(t *testing.T) {
+	cmd := AdvanceStep{Namespace: "github.com/org/repo"}
+	err := cmd.Validate(nil)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, asynxModels.ErrValidation))
+}
+
+func TestAdvanceStep_Validate_NoActiveRun_ReturnsError(t *testing.T) {
+	cmd := AdvanceStep{Namespace: "github.com/org/repo"}
+	rt := &domainRuntime.ArrowRuntime{Namespace: "github.com/org/repo"}
+	err := cmd.Validate(rt)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, asynxModels.ErrValidation))
+}
+
+func TestAdvanceStep_EmitEvent_UpdatesStepStatus(t *testing.T) {
+	status := domainRuntime.StepStatusCompleted
+	cmd := AdvanceStep{
+		Namespace: "github.com/org/repo",
+		StepIndex: 0,
+		ToStatus:  status,
+	}
+	rt := &domainRuntime.ArrowRuntime{
+		Namespace: "github.com/org/repo",
+		State:     domain.ArrowStateInstalling,
+		ActiveRun: &domainRuntime.RunRecord{
+			Method: "_install",
+			Steps: []domainRuntime.StepProgress{
+				{Index: 0, Status: domainRuntime.StepStatusPending},
+			},
+		},
+	}
+	result := cmd.EmitEvent(rt)
+	require.NotNil(t, result.ActiveRun)
+	assert.Equal(t, status, result.ActiveRun.Steps[0].Status)
+}

--- a/internal/app/arrow/commands/begin_execution.go
+++ b/internal/app/arrow/commands/begin_execution.go
@@ -1,1 +1,105 @@
 package commands
+
+import (
+	"fmt"
+
+	asynxModels "github.com/char2cs/asynx/models"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	domainRuntime "github.com/rabbytesoftware/quiver/internal/domain/runtime"
+	domainStep "github.com/rabbytesoftware/quiver/internal/domain/runtime/step"
+)
+
+type BeginExecution struct {
+	Namespace   domain.Namespace
+	Method      string
+	AvailableIn []domain.ArrowState
+	Steps       []domainStep.Step
+	Variables   map[string]string
+}
+
+func (c BeginExecution) AggregateID() string {
+	return c.Namespace.String()
+}
+
+func (c BeginExecution) EventName() string {
+	return "runtime.begun"
+}
+
+func (c BeginExecution) ShouldSnapshot() bool {
+	return false
+}
+
+func (c BeginExecution) Validate(current *domainRuntime.ArrowRuntime) error {
+	absent := current == nil || current.Namespace == ""
+
+	if absent {
+		if c.AvailableIn == nil {
+			return nil
+		}
+		for _, s := range c.AvailableIn {
+			if s == domain.ArrowStateAbsent {
+				return nil
+			}
+		}
+		return fmt.Errorf("begin execution: %w", asynxModels.ErrValidation)
+	}
+
+	if current.ActiveRun != nil {
+		return fmt.Errorf("begin execution: %w", asynxModels.ErrValidation)
+	}
+
+	if c.AvailableIn == nil {
+		return nil
+	}
+
+	for _, s := range c.AvailableIn {
+		if s == current.State {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("begin execution: %w", asynxModels.ErrValidation)
+}
+
+func (c BeginExecution) EmitEvent(current *domainRuntime.ArrowRuntime) domainRuntime.ArrowRuntime {
+	newState := stateForMethod(c.Method)
+
+	return domainRuntime.ArrowRuntime{
+		Namespace:  c.Namespace,
+		State:      newState,
+		ActiveRun:  &domainRuntime.RunRecord{Method: c.Method, Steps: initialSteps(c.Steps), Variables: c.Variables},
+		LastReturn: preserveLastReturn(current),
+	}
+}
+
+func stateForMethod(method string) domain.ArrowState {
+	switch method {
+	case "_install":
+		return domain.ArrowStateInstalling
+	case "_uninstall":
+		return domain.ArrowStateUninstalling
+	case "_stop":
+		return domain.ArrowStateStopping
+	default:
+		return domain.ArrowStateRunning
+	}
+}
+
+func initialSteps(steps []domainStep.Step) []domainRuntime.StepProgress {
+	result := make([]domainRuntime.StepProgress, len(steps))
+	for i, s := range steps {
+		result[i] = domainRuntime.StepProgress{
+			Index:  i,
+			Status: domainRuntime.StepStatusPending,
+			Step:   s,
+		}
+	}
+	return result
+}
+
+func preserveLastReturn(current *domainRuntime.ArrowRuntime) *domainRuntime.Return {
+	if current == nil {
+		return nil
+	}
+	return current.LastReturn
+}

--- a/internal/app/arrow/commands/begin_execution_test.go
+++ b/internal/app/arrow/commands/begin_execution_test.go
@@ -1,0 +1,52 @@
+package commands
+
+import (
+	"errors"
+	"testing"
+
+	asynxModels "github.com/char2cs/asynx/models"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	domainRuntime "github.com/rabbytesoftware/quiver/internal/domain/runtime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBeginExecution_AggregateID(t *testing.T) {
+	cmd := BeginExecution{Namespace: "github.com/org/repo"}
+	assert.Equal(t, "github.com/org/repo", cmd.AggregateID())
+}
+
+func TestBeginExecution_EventName(t *testing.T) {
+	assert.Equal(t, "runtime.begun", BeginExecution{}.EventName())
+}
+
+func TestBeginExecution_Validate_NilRuntime_NoAvailableIn_ReturnsNil(t *testing.T) {
+	cmd := BeginExecution{Namespace: "github.com/org/repo"}
+	require.NoError(t, cmd.Validate(nil))
+}
+
+func TestBeginExecution_Validate_AlreadyRunning_ReturnsError(t *testing.T) {
+	cmd := BeginExecution{Namespace: "github.com/org/repo"}
+	rt := &domainRuntime.ArrowRuntime{
+		Namespace: "github.com/org/repo",
+		State:     domain.ArrowStateRunning,
+		ActiveRun: &domainRuntime.RunRecord{Method: "_execute"},
+	}
+	err := cmd.Validate(rt)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, asynxModels.ErrValidation))
+}
+
+func TestBeginExecution_EmitEvent_SetsRunningState(t *testing.T) {
+	cmd := BeginExecution{Namespace: "github.com/org/repo", Method: "_execute"}
+	result := cmd.EmitEvent(nil)
+	assert.Equal(t, domain.ArrowStateRunning, result.State)
+	require.NotNil(t, result.ActiveRun)
+	assert.Equal(t, "_execute", result.ActiveRun.Method)
+}
+
+func TestBeginExecution_EmitEvent_InstallMethod_SetsInstalling(t *testing.T) {
+	cmd := BeginExecution{Namespace: "github.com/org/repo", Method: "_install"}
+	result := cmd.EmitEvent(nil)
+	assert.Equal(t, domain.ArrowStateInstalling, result.State)
+}

--- a/internal/app/arrow/commands/end_execution.go
+++ b/internal/app/arrow/commands/end_execution.go
@@ -1,1 +1,73 @@
 package commands
+
+import (
+	"fmt"
+
+	asynxModels "github.com/char2cs/asynx/models"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	domainRuntime "github.com/rabbytesoftware/quiver/internal/domain/runtime"
+)
+
+type EndExecution struct {
+	Namespace domain.Namespace
+	Outcome   domainRuntime.ExecutionOutcome
+}
+
+func (c EndExecution) AggregateID() string {
+	return c.Namespace.String()
+}
+
+func (c EndExecution) EventName() string {
+	return "runtime.ended"
+}
+
+func (c EndExecution) ShouldSnapshot() bool {
+	return false
+}
+
+func (c EndExecution) Validate(current *domainRuntime.ArrowRuntime) error {
+	if current == nil || current.Namespace == "" {
+		return fmt.Errorf("end execution: %w", asynxModels.ErrValidation)
+	}
+	if current.ActiveRun == nil {
+		return fmt.Errorf("end execution: %w", asynxModels.ErrValidation)
+	}
+	return nil
+}
+
+func (c EndExecution) EmitEvent(current *domainRuntime.ArrowRuntime) domainRuntime.ArrowRuntime {
+	activeRun := current.ActiveRun
+
+	ret := domainRuntime.Return{
+		Method:    activeRun.Method,
+		Outcome:   c.Outcome,
+		Steps:     activeRun.Steps,
+		Variables: activeRun.Variables,
+	}
+
+	newState := stateAfterEnd(activeRun.Method, c.Outcome)
+
+	return domainRuntime.ArrowRuntime{
+		Namespace:  c.Namespace,
+		State:      newState,
+		ActiveRun:  nil,
+		LastReturn: &ret,
+	}
+}
+
+func stateAfterEnd(method string, outcome domainRuntime.ExecutionOutcome) domain.ArrowState {
+	switch method {
+	case "_install":
+		if outcome == domainRuntime.ExecutionOutcomeSuccess {
+			return domain.ArrowStateReady
+		}
+		return domain.ArrowStateAbsent
+	case "_uninstall":
+		if outcome == domainRuntime.ExecutionOutcomeSuccess {
+			return domain.ArrowStateAbsent
+		}
+		return domain.ArrowStateReady
+	default:
+		return domain.ArrowStateReady
+	}
+}

--- a/internal/app/arrow/commands/end_execution_test.go
+++ b/internal/app/arrow/commands/end_execution_test.go
@@ -1,0 +1,69 @@
+package commands
+
+import (
+	"errors"
+	"testing"
+
+	asynxModels "github.com/char2cs/asynx/models"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	domainRuntime "github.com/rabbytesoftware/quiver/internal/domain/runtime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEndExecution_AggregateID(t *testing.T) {
+	cmd := EndExecution{Namespace: "github.com/org/repo"}
+	assert.Equal(t, "github.com/org/repo", cmd.AggregateID())
+}
+
+func TestEndExecution_EventName(t *testing.T) {
+	assert.Equal(t, "runtime.ended", EndExecution{}.EventName())
+}
+
+func TestEndExecution_Validate_NilRuntime_ReturnsError(t *testing.T) {
+	cmd := EndExecution{Namespace: "github.com/org/repo"}
+	err := cmd.Validate(nil)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, asynxModels.ErrValidation))
+}
+
+func TestEndExecution_Validate_NoActiveRun_ReturnsError(t *testing.T) {
+	cmd := EndExecution{Namespace: "github.com/org/repo"}
+	rt := &domainRuntime.ArrowRuntime{Namespace: "github.com/org/repo", State: domain.ArrowStateReady}
+	err := cmd.Validate(rt)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, asynxModels.ErrValidation))
+}
+
+func TestEndExecution_Validate_WithActiveRun_ReturnsNil(t *testing.T) {
+	cmd := EndExecution{Namespace: "github.com/org/repo"}
+	rt := &domainRuntime.ArrowRuntime{
+		Namespace: "github.com/org/repo",
+		State:     domain.ArrowStateRunning,
+		ActiveRun: &domainRuntime.RunRecord{Method: "_execute"},
+	}
+	require.NoError(t, cmd.Validate(rt))
+}
+
+func TestEndExecution_EmitEvent_InstallSuccess_SetsReady(t *testing.T) {
+	cmd := EndExecution{Namespace: "github.com/org/repo", Outcome: domainRuntime.ExecutionOutcomeSuccess}
+	rt := &domainRuntime.ArrowRuntime{
+		Namespace: "github.com/org/repo",
+		ActiveRun: &domainRuntime.RunRecord{Method: "_install"},
+	}
+	result := cmd.EmitEvent(rt)
+	assert.Equal(t, domain.ArrowStateReady, result.State)
+	assert.Nil(t, result.ActiveRun)
+	require.NotNil(t, result.LastReturn)
+	assert.Equal(t, domainRuntime.ExecutionOutcomeSuccess, result.LastReturn.Outcome)
+}
+
+func TestEndExecution_EmitEvent_InstallFailed_SetsAbsent(t *testing.T) {
+	cmd := EndExecution{Namespace: "github.com/org/repo", Outcome: domainRuntime.ExecutionOutcomeFailed}
+	rt := &domainRuntime.ArrowRuntime{
+		Namespace: "github.com/org/repo",
+		ActiveRun: &domainRuntime.RunRecord{Method: "_install"},
+	}
+	result := cmd.EmitEvent(rt)
+	assert.Equal(t, domain.ArrowStateAbsent, result.State)
+}

--- a/internal/app/arrow/commands/mark_stopping.go
+++ b/internal/app/arrow/commands/mark_stopping.go
@@ -1,1 +1,44 @@
 package commands
+
+import (
+	"fmt"
+
+	asynxModels "github.com/char2cs/asynx/models"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	domainRuntime "github.com/rabbytesoftware/quiver/internal/domain/runtime"
+)
+
+type MarkStopping struct {
+	Namespace domain.Namespace
+}
+
+func (c MarkStopping) AggregateID() string {
+	return c.Namespace.String()
+}
+
+func (c MarkStopping) EventName() string {
+	return "runtime.mark_stopping"
+}
+
+func (c MarkStopping) ShouldSnapshot() bool {
+	return false
+}
+
+func (c MarkStopping) Validate(current *domainRuntime.ArrowRuntime) error {
+	if current == nil || current.Namespace == "" {
+		return fmt.Errorf("mark stopping: %w", asynxModels.ErrValidation)
+	}
+	if current.State != domain.ArrowStateRunning {
+		return fmt.Errorf("mark stopping: %w", asynxModels.ErrValidation)
+	}
+	return nil
+}
+
+func (c MarkStopping) EmitEvent(current *domainRuntime.ArrowRuntime) domainRuntime.ArrowRuntime {
+	return domainRuntime.ArrowRuntime{
+		Namespace:  current.Namespace,
+		State:      domain.ArrowStateStopping,
+		ActiveRun:  current.ActiveRun,
+		LastReturn: current.LastReturn,
+	}
+}

--- a/internal/app/arrow/commands/mark_stopping_test.go
+++ b/internal/app/arrow/commands/mark_stopping_test.go
@@ -1,0 +1,49 @@
+package commands
+
+import (
+	"errors"
+	"testing"
+
+	asynxModels "github.com/char2cs/asynx/models"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	domainRuntime "github.com/rabbytesoftware/quiver/internal/domain/runtime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarkStopping_AggregateID(t *testing.T) {
+	cmd := MarkStopping{Namespace: "github.com/org/repo"}
+	assert.Equal(t, "github.com/org/repo", cmd.AggregateID())
+}
+
+func TestMarkStopping_EventName(t *testing.T) {
+	assert.Equal(t, "runtime.mark_stopping", MarkStopping{}.EventName())
+}
+
+func TestMarkStopping_Validate_NilRuntime_ReturnsError(t *testing.T) {
+	cmd := MarkStopping{Namespace: "github.com/org/repo"}
+	err := cmd.Validate(nil)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, asynxModels.ErrValidation))
+}
+
+func TestMarkStopping_Validate_NotRunning_ReturnsError(t *testing.T) {
+	cmd := MarkStopping{Namespace: "github.com/org/repo"}
+	rt := &domainRuntime.ArrowRuntime{Namespace: "github.com/org/repo", State: domain.ArrowStateReady}
+	err := cmd.Validate(rt)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, asynxModels.ErrValidation))
+}
+
+func TestMarkStopping_Validate_Running_ReturnsNil(t *testing.T) {
+	cmd := MarkStopping{Namespace: "github.com/org/repo"}
+	rt := &domainRuntime.ArrowRuntime{Namespace: "github.com/org/repo", State: domain.ArrowStateRunning}
+	require.NoError(t, cmd.Validate(rt))
+}
+
+func TestMarkStopping_EmitEvent_SetsStopping(t *testing.T) {
+	cmd := MarkStopping{Namespace: "github.com/org/repo"}
+	rt := &domainRuntime.ArrowRuntime{Namespace: "github.com/org/repo", State: domain.ArrowStateRunning}
+	result := cmd.EmitEvent(rt)
+	assert.Equal(t, domain.ArrowStateStopping, result.State)
+}

--- a/internal/app/arrow/commands/remove.go
+++ b/internal/app/arrow/commands/remove.go
@@ -1,1 +1,42 @@
 package commands
+
+import (
+	"fmt"
+
+	asynxModels "github.com/char2cs/asynx/models"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+)
+
+type RemoveArrow struct {
+	Namespace domain.Namespace
+}
+
+func (c RemoveArrow) AggregateID() string {
+	return c.Namespace.String()
+}
+
+func (c RemoveArrow) EventName() string {
+	return "arrow.removed"
+}
+
+func (c RemoveArrow) ShouldSnapshot() bool {
+	return false
+}
+
+func (c RemoveArrow) Validate(current *domain.Arrow) error {
+	if current == nil {
+		return fmt.Errorf("remove arrow: %w", asynxModels.ErrValidation)
+	}
+	if current.Removed {
+		return fmt.Errorf("remove arrow: %w", asynxModels.ErrValidation)
+	}
+	return nil
+}
+
+func (c RemoveArrow) EmitEvent(current *domain.Arrow) domain.Arrow {
+	return domain.Arrow{
+		Namespace: current.Namespace,
+		Manifest:  current.Manifest,
+		Removed:   true,
+	}
+}

--- a/internal/app/arrow/commands/remove_test.go
+++ b/internal/app/arrow/commands/remove_test.go
@@ -1,0 +1,48 @@
+package commands
+
+import (
+	"errors"
+	"testing"
+
+	asynxModels "github.com/char2cs/asynx/models"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoveArrow_AggregateID(t *testing.T) {
+	cmd := RemoveArrow{Namespace: "github.com/org/repo"}
+	assert.Equal(t, "github.com/org/repo", cmd.AggregateID())
+}
+
+func TestRemoveArrow_EventName(t *testing.T) {
+	assert.Equal(t, "arrow.removed", RemoveArrow{}.EventName())
+}
+
+func TestRemoveArrow_Validate_NilState_ReturnsError(t *testing.T) {
+	cmd := RemoveArrow{Namespace: "github.com/org/repo"}
+	err := cmd.Validate(nil)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, asynxModels.ErrValidation))
+}
+
+func TestRemoveArrow_Validate_AlreadyRemoved_ReturnsError(t *testing.T) {
+	cmd := RemoveArrow{Namespace: "github.com/org/repo"}
+	existing := &domain.Arrow{Namespace: "github.com/org/repo", Removed: true}
+	err := cmd.Validate(existing)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, asynxModels.ErrValidation))
+}
+
+func TestRemoveArrow_Validate_Active_ReturnsNil(t *testing.T) {
+	cmd := RemoveArrow{Namespace: "github.com/org/repo"}
+	existing := &domain.Arrow{Namespace: "github.com/org/repo", Removed: false}
+	require.NoError(t, cmd.Validate(existing))
+}
+
+func TestRemoveArrow_EmitEvent_MarksRemoved(t *testing.T) {
+	existing := &domain.Arrow{Namespace: "github.com/org/repo", Removed: false}
+	cmd := RemoveArrow{Namespace: "github.com/org/repo"}
+	result := cmd.EmitEvent(existing)
+	assert.True(t, result.Removed)
+}

--- a/internal/app/arrow/commands/update_manifest.go
+++ b/internal/app/arrow/commands/update_manifest.go
@@ -1,1 +1,43 @@
 package commands
+
+import (
+	"fmt"
+
+	asynxModels "github.com/char2cs/asynx/models"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+)
+
+type UpdateArrowManifest struct {
+	Namespace domain.Namespace
+	Manifest  domain.ArrowManifest
+}
+
+func (c UpdateArrowManifest) AggregateID() string {
+	return c.Namespace.String()
+}
+
+func (c UpdateArrowManifest) EventName() string {
+	return "arrow.updated"
+}
+
+func (c UpdateArrowManifest) ShouldSnapshot() bool {
+	return false
+}
+
+func (c UpdateArrowManifest) Validate(current *domain.Arrow) error {
+	if current == nil {
+		return fmt.Errorf("update arrow: %w", asynxModels.ErrValidation)
+	}
+	if current.Removed {
+		return fmt.Errorf("update arrow: %w", asynxModels.ErrValidation)
+	}
+	return nil
+}
+
+func (c UpdateArrowManifest) EmitEvent(current *domain.Arrow) domain.Arrow {
+	return domain.Arrow{
+		Namespace: current.Namespace,
+		Manifest:  c.Manifest,
+		Removed:   false,
+	}
+}

--- a/internal/app/arrow/commands/update_manifest_test.go
+++ b/internal/app/arrow/commands/update_manifest_test.go
@@ -1,0 +1,50 @@
+package commands
+
+import (
+	"errors"
+	"testing"
+
+	asynxModels "github.com/char2cs/asynx/models"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateArrowManifest_AggregateID(t *testing.T) {
+	cmd := UpdateArrowManifest{Namespace: "github.com/org/repo"}
+	assert.Equal(t, "github.com/org/repo", cmd.AggregateID())
+}
+
+func TestUpdateArrowManifest_EventName(t *testing.T) {
+	assert.Equal(t, "arrow.updated", UpdateArrowManifest{}.EventName())
+}
+
+func TestUpdateArrowManifest_Validate_NilState_ReturnsError(t *testing.T) {
+	cmd := UpdateArrowManifest{Namespace: "github.com/org/repo"}
+	err := cmd.Validate(nil)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, asynxModels.ErrValidation))
+}
+
+func TestUpdateArrowManifest_Validate_Removed_ReturnsError(t *testing.T) {
+	cmd := UpdateArrowManifest{Namespace: "github.com/org/repo"}
+	existing := &domain.Arrow{Namespace: "github.com/org/repo", Removed: true}
+	err := cmd.Validate(existing)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, asynxModels.ErrValidation))
+}
+
+func TestUpdateArrowManifest_Validate_Active_ReturnsNil(t *testing.T) {
+	cmd := UpdateArrowManifest{Namespace: "github.com/org/repo"}
+	existing := &domain.Arrow{Namespace: "github.com/org/repo", Removed: false}
+	require.NoError(t, cmd.Validate(existing))
+}
+
+func TestUpdateArrowManifest_EmitEvent_UpdatesManifest(t *testing.T) {
+	newManifest := domain.ArrowManifest{Name: "Updated", Version: "2.0.0"}
+	existing := &domain.Arrow{Namespace: "github.com/org/repo", Removed: false}
+	cmd := UpdateArrowManifest{Namespace: "github.com/org/repo", Manifest: newManifest}
+	result := cmd.EmitEvent(existing)
+	assert.Equal(t, newManifest, result.Manifest)
+	assert.False(t, result.Removed)
+}

--- a/internal/app/arrow/execution.go
+++ b/internal/app/arrow/execution.go
@@ -1,0 +1,255 @@
+package arrow
+
+import (
+	"context"
+	"errors"
+	"maps"
+	"strconv"
+
+	asynxModels "github.com/char2cs/asynx/models"
+	arrowcmds "github.com/rabbytesoftware/quiver/internal/app/arrow/commands"
+	"github.com/rabbytesoftware/quiver/internal/app/arrow/stepreporter"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	domainRuntime "github.com/rabbytesoftware/quiver/internal/domain/runtime"
+	domainStep "github.com/rabbytesoftware/quiver/internal/domain/runtime/step"
+	"github.com/rabbytesoftware/quiver/internal/engine/deptree"
+	"github.com/rabbytesoftware/quiver/internal/engine/vault"
+	"github.com/rabbytesoftware/quiver/internal/engine/wizard"
+)
+
+func (svc *arrowService) resolveManifest(
+	ctx context.Context,
+	ns domain.Namespace,
+) (*domain.ArrowManifest, string, error) {
+	entry, homePath, err := svc.vault.GetArrow(ctx, ns)
+
+	if err == nil {
+		return entry.Manifest, homePath, nil
+	}
+
+	if errors.Is(err, vault.ErrStale) {
+		manifest, manifoldErr := svc.manifold.ResolveArrow(ctx, ns)
+		if manifoldErr != nil {
+			return entry.Manifest, homePath, nil
+		}
+
+		newPath, putErr := svc.vault.PutArrow(ctx, ns, manifest, nil)
+		if putErr != nil {
+			return nil, "", errors.Join(putErr)
+		}
+
+		return manifest, newPath, nil
+	}
+
+	if errors.Is(err, vault.ErrNotCached) {
+		manifest, manifoldErr := svc.manifold.ResolveArrow(ctx, ns)
+		if manifoldErr != nil {
+			return nil, "", manifoldErr
+		}
+
+		newPath, putErr := svc.vault.PutArrow(ctx, ns, manifest, nil)
+		if putErr != nil {
+			return nil, "", putErr
+		}
+
+		return manifest, newPath, nil
+	}
+
+	return nil, "", err
+}
+
+func (svc *arrowService) buildDepResolver() deptree.ResolverFunc {
+	return func(ctx context.Context, ns domain.Namespace) ([]domain.Namespace, error) {
+		manifest, _, err := svc.resolveManifest(ctx, ns)
+		if err != nil {
+			return nil, err
+		}
+
+		return manifest.Dependencies, nil
+	}
+}
+
+func (svc *arrowService) beginExecution(
+	ctx context.Context,
+	ns domain.Namespace,
+	method string,
+	userVars map[string]string,
+) (*wizard.RunRequest, *stepreporter.StepReporter, error) {
+	arrow, err := svc.asynxArrow.Get(ctx, ns.String())
+	if err != nil {
+		if errors.Is(err, asynxModels.ErrNotFound) {
+			return nil, nil, ErrNotFound
+		}
+		return nil, nil, err
+	}
+
+	steps, availableIn := svc.stepsForMethod(arrow, method)
+
+	vars, err := svc.resolveVariables(ctx, ns, &arrow.Manifest, method, userVars)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if err := svc.asynxRuntime.Send(ctx, arrowcmds.BeginExecution{
+		Namespace:   ns,
+		Method:      method,
+		AvailableIn: availableIn,
+		Steps:       steps,
+		Variables:   vars,
+	}); err != nil {
+		return nil, nil, err
+	}
+
+	_, workDir, _ := svc.vault.GetArrow(ctx, ns)
+
+	indexOffset := 0
+	if method == "_install" {
+		indexOffset = 1
+	}
+
+	reporter := stepreporter.New(svc.asynxRuntime, ns, indexOffset)
+
+	req := &wizard.RunRequest{
+		Namespace: ns,
+		Variables: vars,
+		Steps:     steps,
+		WorkDir:   workDir,
+	}
+
+	return req, reporter, nil
+}
+
+func (svc *arrowService) executeSync(
+	ctx context.Context,
+	ns domain.Namespace,
+	method string,
+	userVars map[string]string,
+) error {
+	req, reporter, err := svc.beginExecution(ctx, ns, method, userVars)
+	if err != nil {
+		return err
+	}
+
+	execErr := svc.wizard.Execute(ctx, *req, reporter)
+	outcome := svc.mapOutcome(execErr)
+	_ = svc.asynxRuntime.Send(ctx, arrowcmds.EndExecution{
+		Namespace: ns,
+		Outcome:   outcome,
+	})
+	return execErr
+}
+
+func (svc *arrowService) resolveVariables(
+	ctx context.Context,
+	ns domain.Namespace,
+	manifest *domain.ArrowManifest,
+	method string,
+	userVars map[string]string,
+) (map[string]string, error) {
+	vars := make(map[string]string)
+
+	// Layer 1: built-ins
+	if entry, homePath, err := svc.vault.GetArrow(ctx, ns); err == nil && entry != nil {
+		vars["INSTALL_PATH"] = homePath
+	}
+	vars["ARROW_NAMESPACE"] = ns.String()
+	vars["PLATFORM"] = svc.os
+
+	// Layer 2: dep built-ins
+	for _, dep := range manifest.Dependencies {
+		if entry, homePath, err := svc.vault.GetArrow(ctx, dep); err == nil && entry != nil {
+			vars[dep.String()+".INSTALL_PATH"] = homePath
+		}
+	}
+
+	// Layer 3: manifest defaults
+	for _, v := range manifest.Variables {
+		if v.Default != "" {
+			vars[v.Name] = v.Default
+		}
+	}
+
+	// Layer 4: netbridge ports
+	if svc.netbridge != nil {
+		for _, port := range manifest.Netbridge {
+			allocated, err := svc.netbridge.Allocate(ctx, ns.String(), port.Protocol, port.Default)
+			if err != nil {
+				if port.Required {
+					return nil, err
+				}
+				continue
+			}
+			vars[port.Name] = strconv.Itoa(allocated)
+		}
+	}
+
+	// Layer 5: stored vars from last return
+	runtime, err := svc.asynxRuntime.Get(ctx, ns.String())
+	if err == nil && runtime.LastReturn != nil {
+		maps.Copy(vars, runtime.LastReturn.Variables)
+	}
+
+	// Layer 6: user vars
+	maps.Copy(vars, userVars)
+
+	return vars, nil
+}
+
+func (svc *arrowService) handleExecutionError(
+	ctx context.Context,
+	ns domain.Namespace,
+	method string,
+	err error,
+) {
+	if method != "_execute" {
+		return
+	}
+	if !errors.Is(err, context.Canceled) {
+		return
+	}
+
+	arrow, getErr := svc.asynxArrow.Get(ctx, ns.String())
+	if getErr != nil {
+		return
+	}
+
+	if arrow.Manifest.Lifecycle.Stop == nil {
+		return
+	}
+
+	go func() {
+		_ = svc.BeginExecution(context.Background(), ns, "_stop", nil)
+	}()
+}
+
+func (svc *arrowService) mapOutcome(err error) domainRuntime.ExecutionOutcome {
+	if err == nil {
+		return domainRuntime.ExecutionOutcomeSuccess
+	}
+	if errors.Is(err, context.Canceled) {
+		return domainRuntime.ExecutionOutcomeCancelled
+	}
+	return domainRuntime.ExecutionOutcomeFailed
+}
+
+func (svc *arrowService) stepsForMethod(
+	arrow domain.Arrow,
+	method string,
+) ([]domainStep.Step, []domain.ArrowState) {
+	switch method {
+	case "_install":
+		depStep := domainStep.NewDependenciesStep("Resolve dependencies")
+		installSteps := []domainStep.Step{depStep}
+		installSteps = append(installSteps, arrow.Manifest.Lifecycle.Install...)
+		return installSteps, nil
+	case "_uninstall":
+		return arrow.Manifest.Lifecycle.Uninstall, []domain.ArrowState{domain.ArrowStateReady}
+	case "_execute":
+		return arrow.Manifest.Lifecycle.Execute, []domain.ArrowState{domain.ArrowStateReady}
+	case "_stop":
+		return arrow.Manifest.Lifecycle.Stop, []domain.ArrowState{domain.ArrowStateReady}
+	default:
+		m := arrow.Manifest.Methods[method]
+		return m.Steps, m.AvailableIn
+	}
+}

--- a/internal/app/arrow/execution_test.go
+++ b/internal/app/arrow/execution_test.go
@@ -1,0 +1,452 @@
+package arrow
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	"github.com/rabbytesoftware/quiver/internal/domain/netbridge"
+	domainRuntime "github.com/rabbytesoftware/quiver/internal/domain/runtime"
+	domainStep "github.com/rabbytesoftware/quiver/internal/domain/runtime/step"
+	"github.com/rabbytesoftware/quiver/internal/engine/vault"
+	"github.com/rabbytesoftware/quiver/internal/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- mapOutcome ---
+
+func TestMapOutcome_Nil_ReturnsSuccess(t *testing.T) {
+	svc := &arrowService{}
+	assert.Equal(t, domainRuntime.ExecutionOutcomeSuccess, svc.mapOutcome(nil))
+}
+
+func TestMapOutcome_ContextCanceled_ReturnsCancelled(t *testing.T) {
+	svc := &arrowService{}
+	assert.Equal(t, domainRuntime.ExecutionOutcomeCancelled, svc.mapOutcome(context.Canceled))
+}
+
+func TestMapOutcome_OtherError_ReturnsFailed(t *testing.T) {
+	svc := &arrowService{}
+	assert.Equal(t, domainRuntime.ExecutionOutcomeFailed, svc.mapOutcome(errors.New("boom")))
+}
+
+// --- resolveVariables ---
+
+func TestResolveVariables_ReturnsBuiltins(t *testing.T) {
+	mv := &mocks.Vault{
+		GetArrowEntry: &vault.VaultEntry{Manifest: makeTestManifest("A")},
+		GetArrowPath:  "/home/arrow",
+	}
+	svc := testArrowService(t, mv, &mocks.Manifold{})
+	svc.os = "darwin"
+
+	manifest := &domain.ArrowManifest{}
+	vars, err := svc.resolveVariables(context.Background(), "github.com/org/repo", manifest, "_execute", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "github.com/org/repo", vars["ARROW_NAMESPACE"])
+	assert.Equal(t, "darwin", vars["PLATFORM"])
+	assert.Equal(t, "/home/arrow", vars["INSTALL_PATH"])
+}
+
+func TestResolveVariables_UserVarsOverrideManifestDefaults(t *testing.T) {
+	mv := &mocks.Vault{GetArrowErr: vault.ErrNotCached}
+	svc := testArrowService(t, mv, &mocks.Manifold{})
+	svc.os = "linux"
+
+	manifest := &domain.ArrowManifest{
+		Variables: []domain.Variable{
+			{Name: "MY_VAR", Default: "default_val"},
+		},
+	}
+	userVars := map[string]string{"MY_VAR": "user_val"}
+
+	vars, err := svc.resolveVariables(context.Background(), "github.com/org/repo", manifest, "_execute", userVars)
+	require.NoError(t, err)
+	assert.Equal(t, "user_val", vars["MY_VAR"])
+}
+
+func TestResolveVariables_ManifestDefaultsApplied(t *testing.T) {
+	mv := &mocks.Vault{GetArrowErr: vault.ErrNotCached}
+	svc := testArrowService(t, mv, &mocks.Manifold{})
+	svc.os = "linux"
+
+	manifest := &domain.ArrowManifest{
+		Variables: []domain.Variable{
+			{Name: "TIMEOUT", Default: "30"},
+		},
+	}
+
+	vars, err := svc.resolveVariables(context.Background(), "github.com/org/repo", manifest, "_execute", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "30", vars["TIMEOUT"])
+}
+
+func TestResolveVariables_NetbridgePortsAdded(t *testing.T) {
+	mv := &mocks.Vault{GetArrowErr: vault.ErrNotCached}
+	nb := &mocks.Netbridge{AllocatePort: 5000}
+	svc := testArrowService(t, mv, &mocks.Manifold{})
+	svc.netbridge = nb
+	svc.os = "linux"
+
+	manifest := &domain.ArrowManifest{
+		Netbridge: []netbridge.PortDef{
+			{Name: "HTTP_PORT", Protocol: netbridge.ProtocolTCP, Default: 8080, Required: false},
+		},
+	}
+
+	vars, err := svc.resolveVariables(context.Background(), "github.com/org/repo", manifest, "_execute", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "5000", vars["HTTP_PORT"])
+}
+
+func TestResolveVariables_StoredVarsFromLastReturn(t *testing.T) {
+	mv := &mocks.Vault{GetArrowErr: vault.ErrNotCached}
+	mm := &mocks.Manifold{}
+	svc := testArrowService(t, mv, mm)
+	svc.os = "linux"
+
+	ns := domain.Namespace("github.com/org/repo")
+
+	// seed a LastReturn in the runtime
+	err := svc.asynxRuntime.Send(context.Background(), mocks.RuntimeCmd{
+		NS:    ns,
+		State: domain.ArrowStateReady,
+	})
+	require.NoError(t, err)
+
+	// inject a runtime with LastReturn via a direct command
+	storedVars := map[string]string{"STORED_KEY": "stored_val"}
+	err = svc.asynxRuntime.Send(context.Background(), endExecutionWithVarsCmd{
+		ns:   ns,
+		vars: storedVars,
+	})
+	require.NoError(t, err)
+	svc.asynxRuntime.WaitPublish()
+
+	manifest := &domain.ArrowManifest{}
+	vars, err := svc.resolveVariables(context.Background(), ns, manifest, "_execute", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "stored_val", vars["STORED_KEY"])
+}
+
+// endExecutionWithVarsCmd injects a LastReturn with specific variables for testing.
+type endExecutionWithVarsCmd struct {
+	ns   domain.Namespace
+	vars map[string]string
+}
+
+func (c endExecutionWithVarsCmd) AggregateID() string                          { return c.ns.String() }
+func (c endExecutionWithVarsCmd) EventName() string                            { return "runtime.mock_end" }
+func (c endExecutionWithVarsCmd) ShouldSnapshot() bool                         { return false }
+func (c endExecutionWithVarsCmd) Validate(_ *domainRuntime.ArrowRuntime) error { return nil }
+func (c endExecutionWithVarsCmd) EmitEvent(_ *domainRuntime.ArrowRuntime) domainRuntime.ArrowRuntime {
+	return domainRuntime.ArrowRuntime{
+		Namespace: c.ns,
+		State:     domain.ArrowStateReady,
+		LastReturn: &domainRuntime.Return{
+			Method:    "_execute",
+			Outcome:   domainRuntime.ExecutionOutcomeSuccess,
+			Variables: c.vars,
+		},
+	}
+}
+
+// --- Stop ---
+
+func TestStop_NotFound_ReturnsErrNotFound(t *testing.T) {
+	mv := &mocks.Vault{GetArrowErr: vault.ErrNotCached}
+	svc := testArrowService(t, mv, &mocks.Manifold{})
+
+	err := svc.Stop(context.Background(), "github.com/org/repo")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestStop_StateNotRunning_ReturnsErrStateViolation(t *testing.T) {
+	mv := &mocks.Vault{GetArrowErr: vault.ErrNotCached}
+	svc := testArrowService(t, mv, &mocks.Manifold{})
+
+	ns := domain.Namespace("github.com/org/repo")
+	require.NoError(t, svc.asynxRuntime.Send(context.Background(), mocks.RuntimeCmd{
+		NS:    ns,
+		State: domain.ArrowStateReady,
+	}))
+	svc.asynxRuntime.WaitPublish()
+
+	err := svc.Stop(context.Background(), ns)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrStateViolation)
+}
+
+func TestStop_StateRunning_SendsMarkStopping(t *testing.T) {
+	mv := &mocks.Vault{GetArrowErr: vault.ErrNotCached}
+	svc := testArrowService(t, mv, &mocks.Manifold{})
+
+	ns := domain.Namespace("github.com/org/repo")
+	require.NoError(t, svc.asynxRuntime.Send(context.Background(), mocks.RuntimeCmd{
+		NS:    ns,
+		State: domain.ArrowStateRunning,
+	}))
+	svc.asynxRuntime.WaitPublish()
+
+	err := svc.Stop(context.Background(), ns)
+	require.NoError(t, err)
+
+	svc.asynxRuntime.WaitPublish()
+
+	runtime, err := svc.asynxRuntime.Get(context.Background(), ns.String())
+	require.NoError(t, err)
+	assert.Equal(t, domain.ArrowStateStopping, runtime.State)
+}
+
+// --- HandleExecutionError ---
+
+func TestHandleExecutionError_NonExecuteMethod_NoStop(t *testing.T) {
+	mv := &mocks.Vault{GetArrowErr: vault.ErrNotCached}
+	svc := testArrowService(t, mv, &mocks.Manifold{})
+	mw := &mocks.Wizard{}
+	svc.wizard = mw
+
+	svc.handleExecutionError(context.Background(), "github.com/org/repo", "_install", context.Canceled)
+
+	// No stop should be dispatched for _install
+	assert.False(t, mw.WasExecuteCalled())
+}
+
+func TestHandleExecutionError_ExecuteMethodNotCanceled_NoStop(t *testing.T) {
+	mv := &mocks.Vault{GetArrowErr: vault.ErrNotCached}
+	svc := testArrowService(t, mv, &mocks.Manifold{})
+	mw := &mocks.Wizard{}
+	svc.wizard = mw
+
+	svc.handleExecutionError(context.Background(), "github.com/org/repo", "_execute", errors.New("other error"))
+
+	assert.False(t, mw.WasExecuteCalled())
+}
+
+func TestHandleExecutionError_ExecuteCanceled_WithStopLifecycle_DispatchesStop(t *testing.T) {
+	stopStep := domainStep.NewDependenciesStep("stop")
+	manifest := &domain.ArrowManifest{
+		Name:    "TestArrow",
+		Version: "1.0.0",
+		Lifecycle: domain.Lifecycle{
+			Stop: domainStep.StepList{stopStep},
+		},
+	}
+
+	mv := &mocks.Vault{
+		GetArrowErr:  vault.ErrNotCached,
+		PutArrowPath: "/tmp/test",
+	}
+	mm := &mocks.Manifold{ResolveArrowManifest: manifest}
+	svc := testArrowService(t, mv, mm)
+	mw := &mocks.Wizard{}
+	svc.wizard = mw
+
+	ns := domain.Namespace("github.com/org/repo")
+	addArrowForTest(t, svc, ns, manifest)
+
+	// Set runtime to ready — handleExecutionError is called after EndExecution sets state to ready
+	require.NoError(t, svc.asynxRuntime.Send(context.Background(), mocks.RuntimeCmd{
+		NS:    ns,
+		State: domain.ArrowStateReady,
+	}))
+	svc.asynxRuntime.WaitPublish()
+
+	svc.handleExecutionError(context.Background(), ns, "_execute", context.Canceled)
+
+	// Wait for goroutine
+	time.Sleep(100 * time.Millisecond)
+
+	assert.True(t, mw.WasExecuteCalled())
+}
+
+func TestHandleExecutionError_ExecuteCanceled_NoStopLifecycle_NoStop(t *testing.T) {
+	manifest := &domain.ArrowManifest{
+		Name:    "TestArrow",
+		Version: "1.0.0",
+	}
+
+	mv := &mocks.Vault{
+		GetArrowErr:  vault.ErrNotCached,
+		PutArrowPath: "/tmp/test",
+	}
+	mm := &mocks.Manifold{ResolveArrowManifest: manifest}
+	svc := testArrowService(t, mv, mm)
+	mw := &mocks.Wizard{}
+	svc.wizard = mw
+
+	ns := domain.Namespace("github.com/org/repo")
+	addArrowForTest(t, svc, ns, manifest)
+
+	svc.handleExecutionError(context.Background(), ns, "_execute", context.Canceled)
+
+	time.Sleep(50 * time.Millisecond)
+	assert.False(t, mw.WasExecuteCalled())
+}
+
+// --- resolveManifest ---
+
+func TestResolveManifest_FreshVaultHit_ReturnsManifestDirectly(t *testing.T) {
+	manifest := makeTestManifest("FreshArrow")
+	mv := &mocks.Vault{
+		GetArrowEntry: &vault.VaultEntry{Manifest: manifest},
+		GetArrowPath:  "/home/fresh",
+		GetArrowErr:   nil,
+	}
+	mm := &mocks.Manifold{}
+	svc := makeArrowServiceWithMocks(mv, mm)
+
+	got, path, err := svc.resolveManifest(context.Background(), "github.com/org/repo")
+	require.NoError(t, err)
+	assert.Equal(t, manifest, got)
+	assert.Equal(t, "/home/fresh", path)
+	assert.Equal(t, 0, mv.PutArrowCalls)
+}
+
+func TestResolveManifest_StaleVaultManifoldSucceeds_ReturnsFreshManifest(t *testing.T) {
+	staleManifest := makeTestManifest("StaleArrow")
+	freshManifest := makeTestManifest("FreshArrow")
+	mv := &mocks.Vault{
+		GetArrowEntry: &vault.VaultEntry{Manifest: staleManifest},
+		GetArrowPath:  "/home/stale",
+		GetArrowErr:   vault.ErrStale,
+		PutArrowPath:  "/home/fresh",
+	}
+	mm := &mocks.Manifold{ResolveArrowManifest: freshManifest}
+	svc := makeArrowServiceWithMocks(mv, mm)
+
+	got, path, err := svc.resolveManifest(context.Background(), "github.com/org/repo")
+	require.NoError(t, err)
+	assert.Equal(t, freshManifest, got)
+	assert.Equal(t, "/home/fresh", path)
+	assert.Equal(t, 1, mv.PutArrowCalls)
+}
+
+func TestResolveManifest_StaleVaultManifoldFails_ReturnsStaleManifest(t *testing.T) {
+	staleManifest := makeTestManifest("StaleArrow")
+	mv := &mocks.Vault{
+		GetArrowEntry: &vault.VaultEntry{Manifest: staleManifest},
+		GetArrowPath:  "/home/stale",
+		GetArrowErr:   vault.ErrStale,
+	}
+	mm := &mocks.Manifold{ResolveArrowErr: errors.New("network error")}
+	svc := makeArrowServiceWithMocks(mv, mm)
+
+	got, path, err := svc.resolveManifest(context.Background(), "github.com/org/repo")
+	require.NoError(t, err)
+	assert.Equal(t, staleManifest, got)
+	assert.Equal(t, "/home/stale", path)
+	assert.Equal(t, 0, mv.PutArrowCalls)
+}
+
+func TestResolveManifest_NotCachedManifoldSucceeds_ReturnsManifestAndStores(t *testing.T) {
+	freshManifest := makeTestManifest("NewArrow")
+	mv := &mocks.Vault{
+		GetArrowErr:  vault.ErrNotCached,
+		PutArrowPath: "/home/new",
+	}
+	mm := &mocks.Manifold{ResolveArrowManifest: freshManifest}
+	svc := makeArrowServiceWithMocks(mv, mm)
+
+	got, path, err := svc.resolveManifest(context.Background(), "github.com/org/repo")
+	require.NoError(t, err)
+	assert.Equal(t, freshManifest, got)
+	assert.Equal(t, "/home/new", path)
+	assert.Equal(t, 1, mv.PutArrowCalls)
+}
+
+func TestResolveManifest_NotCachedManifoldFails_ReturnsError(t *testing.T) {
+	mv := &mocks.Vault{
+		GetArrowErr: vault.ErrNotCached,
+	}
+	mm := &mocks.Manifold{ResolveArrowErr: errors.New("network error")}
+	svc := makeArrowServiceWithMocks(mv, mm)
+
+	got, path, err := svc.resolveManifest(context.Background(), "github.com/org/repo")
+	assert.Error(t, err)
+	assert.Nil(t, got)
+	assert.Empty(t, path)
+}
+
+func TestResolveManifest_StaleVaultPutFails_ReturnsError(t *testing.T) {
+	staleManifest := makeTestManifest("StaleArrow")
+	freshManifest := makeTestManifest("FreshArrow")
+	mv := &mocks.Vault{
+		GetArrowEntry: &vault.VaultEntry{Manifest: staleManifest},
+		GetArrowPath:  "/home/stale",
+		GetArrowErr:   vault.ErrStale,
+		PutArrowErr:   errors.New("disk full"),
+	}
+	mm := &mocks.Manifold{ResolveArrowManifest: freshManifest}
+	svc := makeArrowServiceWithMocks(mv, mm)
+
+	got, path, err := svc.resolveManifest(context.Background(), "github.com/org/repo")
+	assert.Error(t, err)
+	assert.Nil(t, got)
+	assert.Empty(t, path)
+}
+
+func TestResolveManifest_NotCachedPutFails_ReturnsError(t *testing.T) {
+	freshManifest := makeTestManifest("NewArrow")
+	mv := &mocks.Vault{
+		GetArrowErr: vault.ErrNotCached,
+		PutArrowErr: errors.New("disk full"),
+	}
+	mm := &mocks.Manifold{ResolveArrowManifest: freshManifest}
+	svc := makeArrowServiceWithMocks(mv, mm)
+
+	got, path, err := svc.resolveManifest(context.Background(), "github.com/org/repo")
+	assert.Error(t, err)
+	assert.Nil(t, got)
+	assert.Empty(t, path)
+}
+
+func TestResolveManifest_UnexpectedVaultError_ReturnsError(t *testing.T) {
+	unexpectedErr := errors.New("disk failure")
+	mv := &mocks.Vault{
+		GetArrowErr: unexpectedErr,
+	}
+	mm := &mocks.Manifold{}
+	svc := makeArrowServiceWithMocks(mv, mm)
+
+	got, path, err := svc.resolveManifest(context.Background(), "github.com/org/repo")
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, unexpectedErr)
+	assert.Nil(t, got)
+	assert.Empty(t, path)
+}
+
+// --- buildDepResolver ---
+
+func TestBuildDepResolver_ReturnsResolverThatReturnsDeps(t *testing.T) {
+	manifest := makeTestManifest("DepArrow")
+	mv := &mocks.Vault{
+		GetArrowEntry: &vault.VaultEntry{Manifest: manifest},
+		GetArrowPath:  "/home/dep",
+		GetArrowErr:   nil,
+	}
+	mm := &mocks.Manifold{}
+	svc := makeArrowServiceWithMocks(mv, mm)
+
+	resolver := svc.buildDepResolver()
+	deps, err := resolver(context.Background(), "github.com/org/repo")
+	require.NoError(t, err)
+	assert.Equal(t, manifest.Dependencies, deps)
+}
+
+func TestBuildDepResolver_ManifoldFails_ReturnsError(t *testing.T) {
+	mv := &mocks.Vault{
+		GetArrowErr: vault.ErrNotCached,
+	}
+	mm := &mocks.Manifold{ResolveArrowErr: errors.New("network error")}
+	svc := makeArrowServiceWithMocks(mv, mm)
+
+	resolver := svc.buildDepResolver()
+	deps, err := resolver(context.Background(), "github.com/org/repo")
+	assert.Error(t, err)
+	assert.Nil(t, deps)
+}

--- a/internal/app/arrow/integration_test.go
+++ b/internal/app/arrow/integration_test.go
@@ -1,0 +1,321 @@
+package arrow
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	sqlite "github.com/rabbytesoftware/quiver/internal/adapter/eventstore/sqlite"
+	arrowstore "github.com/rabbytesoftware/quiver/internal/app/arrow/store"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	"github.com/rabbytesoftware/quiver/internal/engine/deptree"
+	"github.com/rabbytesoftware/quiver/internal/engine/vault"
+	"github.com/rabbytesoftware/quiver/internal/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// integrationFixture wires a real ArrowService with mock engines.
+type integrationFixture struct {
+	svc      ArrowService
+	inner    *arrowService
+	vault    *mockIntegVault
+	manifold *mockIntegManifold
+	wizard   *mocks.Wizard
+}
+
+func newIntegrationFixture(t *testing.T) *integrationFixture {
+	t.Helper()
+
+	arrowES, err := sqlite.NewEventStore(":memory:")
+	require.NoError(t, err)
+
+	runtimeES, err := sqlite.NewEventStore(":memory:")
+	require.NoError(t, err)
+
+	catalog, err := arrowstore.NewArrowCatalogFromPath(":memory:")
+	require.NoError(t, err)
+
+	v := &mockIntegVault{
+		manifests: map[string]*domain.ArrowManifest{},
+		paths:     map[string]string{},
+		indirect:  map[string][]domain.Namespace{},
+	}
+	m := &mockIntegManifold{manifests: map[string]*domain.ArrowManifest{}}
+	w := &mocks.Wizard{}
+
+	svc, err := NewArrowBuilder().
+		WithEventStore(arrowES).
+		WithRuntimeEventStore(runtimeES).
+		WithCatalog(catalog).
+		WithVault(v).
+		WithManifold(m).
+		WithDepTree(deptree.Deptree).
+		WithNetbridge(&mocks.Netbridge{AllocatePort: 8080}).
+		WithWizard(w).
+		WithOS("linux").
+		Build(context.Background())
+	require.NoError(t, err)
+
+	inner := svc.(*arrowService)
+
+	return &integrationFixture{
+		svc:      svc,
+		inner:    inner,
+		vault:    v,
+		manifold: m,
+		wizard:   w,
+	}
+}
+
+// mockIntegVault stores manifests and paths in memory.
+type mockIntegVault struct {
+	mu        sync.Mutex
+	manifests map[string]*domain.ArrowManifest
+	paths     map[string]string
+	indirect  map[string][]domain.Namespace
+}
+
+func (v *mockIntegVault) GetArrow(
+	_ context.Context,
+	ns domain.Namespace,
+) (*vault.VaultEntry, string, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	m, ok := v.manifests[ns.String()]
+	if !ok {
+		return nil, "", vault.ErrNotCached
+	}
+
+	return &vault.VaultEntry{
+		Manifest:             m,
+		IndirectDependencies: v.indirect[ns.String()],
+	}, v.paths[ns.String()], nil
+}
+
+func (v *mockIntegVault) PutArrow(
+	_ context.Context,
+	ns domain.Namespace,
+	manifest *domain.ArrowManifest,
+	indirectDeps []domain.Namespace,
+) (string, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	key := ns.String()
+	v.manifests[key] = manifest
+	path := "/tmp/integ/" + key
+	v.paths[key] = path
+	if indirectDeps != nil {
+		v.indirect[key] = indirectDeps
+	}
+	return path, nil
+}
+
+func (v *mockIntegVault) DeleteArrow(_ context.Context, ns domain.Namespace) error {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	key := ns.String()
+	delete(v.manifests, key)
+	delete(v.paths, key)
+	delete(v.indirect, key)
+	return nil
+}
+
+func (v *mockIntegVault) GetQuiver(
+	_ context.Context,
+	_ domain.Namespace,
+) (*vault.QuiverVaultEntry, string, error) {
+	return nil, "", vault.ErrNotCached
+}
+
+func (v *mockIntegVault) PutQuiver(
+	_ context.Context,
+	_ domain.Namespace,
+	_ *domain.QuiverManifest,
+) (string, error) {
+	return "", nil
+}
+
+func (v *mockIntegVault) DeleteQuiver(_ context.Context, _ domain.Namespace) error {
+	return nil
+}
+
+// mockIntegManifold returns manifests keyed by namespace string.
+type mockIntegManifold struct {
+	mu        sync.Mutex
+	manifests map[string]*domain.ArrowManifest
+}
+
+func (m *mockIntegManifold) ResolveArrow(
+	_ context.Context,
+	ns domain.Namespace,
+) (*domain.ArrowManifest, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	manifest, ok := m.manifests[ns.String()]
+	if !ok {
+		return nil, ErrFetchFailed
+	}
+	return manifest, nil
+}
+
+func (m *mockIntegManifold) ResolveQuiver(
+	_ context.Context,
+	_ domain.Namespace,
+) (*domain.QuiverManifest, error) {
+	return nil, ErrFetchFailed
+}
+
+func (m *mockIntegManifold) set(ns domain.Namespace, manifest *domain.ArrowManifest) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.manifests[ns.String()] = manifest
+}
+
+// --- Integration Tests ---
+
+func TestIntegration_Add_ArrowAppearsInList(t *testing.T) {
+	f := newIntegrationFixture(t)
+	ctx := context.Background()
+
+	ns := domain.Namespace("github.com/test/arrow1")
+	f.manifold.set(ns, &domain.ArrowManifest{Name: "Arrow1", Version: "1.0.0"})
+
+	err := f.svc.Add(ctx, ns)
+	require.NoError(t, err)
+
+	f.inner.asynxArrow.WaitPublish()
+
+	list, err := f.svc.List(ctx)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, ns, list[0].Namespace)
+}
+
+func TestIntegration_Update_ManifestChanges(t *testing.T) {
+	f := newIntegrationFixture(t)
+	ctx := context.Background()
+
+	ns := domain.Namespace("github.com/test/arrow1")
+	f.manifold.set(ns, &domain.ArrowManifest{Name: "Arrow1", Version: "1.0.0"})
+
+	require.NoError(t, f.svc.Add(ctx, ns))
+	f.inner.asynxArrow.WaitPublish()
+
+	f.manifold.set(ns, &domain.ArrowManifest{Name: "Arrow1", Version: "2.0.0"})
+
+	require.NoError(t, f.svc.Update(ctx, ns))
+	f.inner.asynxArrow.WaitPublish()
+
+	detail, err := f.svc.GetDetail(ctx, ns)
+	require.NoError(t, err)
+	assert.Equal(t, "2.0.0", detail.Manifest.Version)
+}
+
+func TestIntegration_Remove_DisappearsFromList(t *testing.T) {
+	f := newIntegrationFixture(t)
+	ctx := context.Background()
+
+	ns := domain.Namespace("github.com/test/arrow1")
+	f.manifold.set(ns, &domain.ArrowManifest{Name: "Arrow1", Version: "1.0.0"})
+
+	require.NoError(t, f.svc.Add(ctx, ns))
+	f.inner.asynxArrow.WaitPublish()
+
+	require.NoError(t, f.svc.Remove(ctx, ns))
+	f.inner.asynxArrow.WaitPublish()
+
+	list, err := f.svc.List(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, list)
+}
+
+func TestIntegration_BeginExecution_WizardExecutesAndStateReturnsToReady(t *testing.T) {
+	f := newIntegrationFixture(t)
+	ctx := context.Background()
+
+	ns := domain.Namespace("github.com/test/arrow1")
+	f.manifold.set(ns, &domain.ArrowManifest{Name: "Arrow1", Version: "1.0.0"})
+
+	require.NoError(t, f.svc.Add(ctx, ns))
+	f.inner.asynxArrow.WaitPublish()
+
+	// Seed runtime to Ready state so BeginExecution is allowed
+	require.NoError(t, f.inner.asynxRuntime.Send(ctx, mocks.RuntimeCmd{
+		NS:    ns,
+		State: domain.ArrowStateReady,
+	}))
+	f.inner.asynxRuntime.WaitPublish()
+
+	err := f.svc.BeginExecution(ctx, ns, "_execute", nil)
+	require.NoError(t, err)
+
+	// Allow async goroutine to complete
+	time.Sleep(50 * time.Millisecond)
+	f.inner.asynxRuntime.WaitPublish()
+
+	detail, err := f.svc.GetDetail(ctx, ns)
+	require.NoError(t, err)
+	assert.Equal(t, domain.ArrowStateReady, detail.State)
+}
+
+func TestIntegration_Stop_CancelsExecution(t *testing.T) {
+	f := newIntegrationFixture(t)
+	ctx := context.Background()
+
+	ns := domain.Namespace("github.com/test/arrow1")
+	f.manifold.set(ns, &domain.ArrowManifest{Name: "Arrow1", Version: "1.0.0"})
+
+	require.NoError(t, f.svc.Add(ctx, ns))
+	f.inner.asynxArrow.WaitPublish()
+
+	// Seed runtime to Running state
+	require.NoError(t, f.inner.asynxRuntime.Send(ctx, mocks.RuntimeCmd{
+		NS:    ns,
+		State: domain.ArrowStateRunning,
+	}))
+	f.inner.asynxRuntime.WaitPublish()
+
+	err := f.svc.Stop(ctx, ns)
+	require.NoError(t, err)
+
+	f.inner.asynxRuntime.WaitPublish()
+
+	detail, err := f.svc.GetDetail(ctx, ns)
+	require.NoError(t, err)
+	assert.Equal(t, domain.ArrowStateStopping, detail.State)
+}
+
+func TestIntegration_GetDetail_IncludesIndirectDeps(t *testing.T) {
+	f := newIntegrationFixture(t)
+	ctx := context.Background()
+
+	ns1 := domain.Namespace("github.com/test/arrow1")
+	ns2 := domain.Namespace("github.com/test/dep")
+
+	f.manifold.set(ns1, &domain.ArrowManifest{
+		Name:         "Arrow1",
+		Version:      "1.0.0",
+		Dependencies: []domain.Namespace{ns2},
+	})
+
+	require.NoError(t, f.svc.Add(ctx, ns1))
+	f.inner.asynxArrow.WaitPublish()
+
+	// Seed vault entry for ns1 with indirect deps
+	_, err := f.vault.PutArrow(ctx, ns1, &domain.ArrowManifest{
+		Name:    "Arrow1",
+		Version: "1.0.0",
+	}, []domain.Namespace{ns2})
+	require.NoError(t, err)
+
+	detail, err := f.svc.GetDetail(ctx, ns1)
+	require.NoError(t, err)
+	require.Len(t, detail.IndirectDependencies, 1)
+	assert.Equal(t, ns2, detail.IndirectDependencies[0])
+}

--- a/internal/app/arrow/lifecycle.go
+++ b/internal/app/arrow/lifecycle.go
@@ -1,0 +1,309 @@
+package arrow
+
+import (
+	"context"
+	"errors"
+
+	asynxModels "github.com/char2cs/asynx/models"
+	arrowcmds "github.com/rabbytesoftware/quiver/internal/app/arrow/commands"
+	"github.com/rabbytesoftware/quiver/internal/app/arrow/stepreporter"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	domainRuntime "github.com/rabbytesoftware/quiver/internal/domain/runtime"
+	"github.com/rabbytesoftware/quiver/internal/engine/deptree"
+	"github.com/rabbytesoftware/quiver/internal/engine/wizard"
+)
+
+func (svc *arrowService) runInstall(
+	ctx context.Context,
+	ns domain.Namespace,
+	userVars map[string]string,
+) {
+	arrow, err := svc.asynxArrow.Get(ctx, ns.String())
+	if err != nil {
+		return
+	}
+
+	vars, err := svc.resolveVariables(ctx, ns, &arrow.Manifest, "_install", userVars)
+	if err != nil {
+		return
+	}
+
+	steps, _ := svc.stepsForMethod(arrow, "_install")
+
+	if err := svc.asynxRuntime.Send(ctx, arrowcmds.BeginExecution{
+		Namespace:   ns,
+		Method:      "_install",
+		AvailableIn: nil,
+		Steps:       steps,
+		Variables:   vars,
+	}); err != nil {
+		return
+	}
+
+	_ = svc.asynxRuntime.Send(ctx, arrowcmds.AdvanceStep{
+		Namespace: ns,
+		StepIndex: 0,
+		ToStatus:  domainRuntime.StepStatusRunning,
+	})
+
+	resolver := svc.buildDepResolver()
+	orderedDeps, err := svc.deptree(ctx, ns, resolver)
+	if err != nil {
+		errStr := err.Error()
+		_ = svc.asynxRuntime.Send(ctx, arrowcmds.AdvanceStep{
+			Namespace: ns,
+			StepIndex: 0,
+			ToStatus:  domainRuntime.StepStatusFailed,
+			Error:     &errStr,
+		})
+		_ = svc.asynxRuntime.Send(ctx, arrowcmds.EndExecution{
+			Namespace: ns,
+			Outcome:   domainRuntime.ExecutionOutcomeFailed,
+		})
+		return
+	}
+
+	_ = svc.asynxRuntime.Send(ctx, arrowcmds.AdvanceStep{
+		Namespace: ns,
+		StepIndex: 0,
+		ToStatus:  domainRuntime.StepStatusCompleted,
+	})
+
+	var installed []domain.Namespace
+
+	for _, dep := range orderedDeps {
+		if dep == ns {
+			continue
+		}
+
+		rt, err := svc.asynxRuntime.Get(ctx, dep.String())
+		if err != nil && !errors.Is(err, asynxModels.ErrNotFound) {
+			// Treat unexpected errors as "not installed" — proceed with install attempt
+			err = nil
+		}
+		if err == nil && rt.Namespace != "" && rt.State != domain.ArrowStateAbsent {
+			continue
+		}
+
+		manifest, _, err := svc.resolveManifest(ctx, dep)
+		if err != nil {
+			svc.rollbackInstalled(ctx, installed)
+			_ = svc.asynxRuntime.Send(ctx, arrowcmds.EndExecution{
+				Namespace: ns,
+				Outcome:   domainRuntime.ExecutionOutcomeFailed,
+			})
+			return
+		}
+
+		existing, getErr := svc.asynxArrow.Get(ctx, dep.String())
+		if errors.Is(getErr, asynxModels.ErrNotFound) || existing.Namespace == "" {
+			_ = svc.asynxArrow.Send(ctx, arrowcmds.AddArrow{
+				Namespace: dep,
+				Manifest:  *manifest,
+			})
+		}
+
+		if err := svc.executeSync(ctx, dep, "_install", nil); err != nil {
+			svc.rollbackInstalled(ctx, installed)
+			_ = svc.asynxRuntime.Send(ctx, arrowcmds.EndExecution{
+				Namespace: ns,
+				Outcome:   domainRuntime.ExecutionOutcomeFailed,
+			})
+			return
+		}
+
+		installed = append(installed, dep)
+	}
+
+	_, workDir, _ := svc.vault.GetArrow(ctx, ns)
+
+	installSteps := arrow.Manifest.Lifecycle.Install
+	reporter := stepreporter.New(svc.asynxRuntime, ns, 1)
+
+	req := wizard.RunRequest{
+		Namespace: ns,
+		Variables: vars,
+		Steps:     installSteps,
+		WorkDir:   workDir,
+	}
+
+	execErr := svc.wizard.Execute(ctx, req, reporter)
+	outcome := svc.mapOutcome(execErr)
+	_ = svc.asynxRuntime.Send(ctx, arrowcmds.EndExecution{
+		Namespace: ns,
+		Outcome:   outcome,
+	})
+
+	if outcome == domainRuntime.ExecutionOutcomeSuccess {
+		svc.updateIndirectDeps(ctx, ns, arrow.Manifest, orderedDeps)
+	}
+}
+
+func (svc *arrowService) rollbackInstalled(ctx context.Context, installed []domain.Namespace) {
+	for i := len(installed) - 1; i >= 0; i-- {
+		dep := installed[i]
+		rt, err := svc.asynxRuntime.Get(ctx, dep.String())
+		if err != nil || rt.State != domain.ArrowStateReady {
+			continue
+		}
+		_ = svc.executeSync(ctx, dep, "_uninstall", nil)
+	}
+}
+
+func (svc *arrowService) updateIndirectDeps(
+	ctx context.Context,
+	ns domain.Namespace,
+	manifest domain.ArrowManifest,
+	deptreeResult []domain.Namespace,
+) {
+	directSet := make(map[string]bool)
+	for _, dep := range manifest.Dependencies {
+		directSet[dep.String()] = true
+	}
+
+	var indirect []domain.Namespace
+	for _, dep := range deptreeResult {
+		if dep == ns || directSet[dep.String()] {
+			continue
+		}
+		indirect = append(indirect, dep)
+	}
+
+	_, _ = svc.vault.PutArrow(ctx, ns, &manifest, indirect)
+}
+
+func (svc *arrowService) runUninstall(
+	ctx context.Context,
+	ns domain.Namespace,
+	userVars map[string]string,
+) {
+	arrow, err := svc.asynxArrow.Get(ctx, ns.String())
+	if err != nil {
+		return
+	}
+
+	vars, err := svc.resolveVariables(ctx, ns, &arrow.Manifest, "_uninstall", userVars)
+	if err != nil {
+		return
+	}
+
+	steps, availableIn := svc.stepsForMethod(arrow, "_uninstall")
+
+	if err := svc.asynxRuntime.Send(ctx, arrowcmds.BeginExecution{
+		Namespace:   ns,
+		Method:      "_uninstall",
+		AvailableIn: availableIn,
+		Steps:       steps,
+		Variables:   vars,
+	}); err != nil {
+		return
+	}
+
+	_, workDir, _ := svc.vault.GetArrow(ctx, ns)
+
+	reporter := stepreporter.New(svc.asynxRuntime, ns, 0)
+
+	req := wizard.RunRequest{
+		Namespace: ns,
+		Variables: vars,
+		Steps:     steps,
+		WorkDir:   workDir,
+	}
+
+	execErr := svc.wizard.Execute(ctx, req, reporter)
+	outcome := svc.mapOutcome(execErr)
+	_ = svc.asynxRuntime.Send(ctx, arrowcmds.EndExecution{
+		Namespace: ns,
+		Outcome:   outcome,
+	})
+
+	if outcome != domainRuntime.ExecutionOutcomeSuccess {
+		return
+	}
+
+	entry, _, err := svc.vault.GetArrow(ctx, ns)
+	if err != nil {
+		_ = svc.vault.DeleteArrow(ctx, ns)
+		return
+	}
+
+	allDeps := make([]domain.Namespace, 0, len(entry.Manifest.Dependencies)+len(entry.IndirectDependencies))
+	allDeps = append(allDeps, entry.Manifest.Dependencies...)
+	allDeps = append(allDeps, entry.IndirectDependencies...)
+
+	orphaned := make(map[domain.Namespace]bool)
+	for _, dep := range allDeps {
+		hasDeps, err := svc.hasDependents(ctx, dep, ns)
+		if err != nil || hasDeps {
+			continue
+		}
+		orphaned[dep] = true
+	}
+
+	vaultResolver := func(resolveCtx context.Context, depNs domain.Namespace) ([]domain.Namespace, error) {
+		depEntry, _, depErr := svc.vault.GetArrow(resolveCtx, depNs)
+		if depErr != nil || depEntry == nil {
+			return nil, nil
+		}
+		return depEntry.Manifest.Dependencies, nil
+	}
+
+	topoOrder, err := svc.deptree(ctx, ns, deptree.ResolverFunc(vaultResolver))
+	if err != nil {
+		_ = svc.vault.DeleteArrow(ctx, ns)
+		return
+	}
+
+	for i := len(topoOrder) - 1; i >= 0; i-- {
+		dep := topoOrder[i]
+		if dep == ns || !orphaned[dep] {
+			continue
+		}
+		if uninstallErr := svc.executeSync(ctx, dep, "_uninstall", nil); uninstallErr != nil {
+			continue
+		}
+		_ = svc.vault.DeleteArrow(ctx, dep)
+	}
+
+	_ = svc.vault.DeleteArrow(ctx, ns)
+}
+
+func (svc *arrowService) hasDependents(
+	ctx context.Context,
+	ns domain.Namespace,
+	excludeNs domain.Namespace,
+) (bool, error) {
+	arrows, err := svc.catalog.List()
+	if err != nil {
+		return false, err
+	}
+
+	for _, arrow := range arrows {
+		if arrow.Removed || arrow.Namespace == excludeNs || arrow.Namespace == ns {
+			continue
+		}
+
+		rt, err := svc.asynxRuntime.Get(ctx, arrow.Namespace.String())
+		if err != nil || rt.State == domain.ArrowStateAbsent || rt.Namespace == "" {
+			continue
+		}
+
+		entry, _, err := svc.vault.GetArrow(ctx, arrow.Namespace)
+		if err != nil {
+			continue
+		}
+
+		for _, dep := range entry.Manifest.Dependencies {
+			if dep == ns {
+				return true, nil
+			}
+		}
+		for _, dep := range entry.IndirectDependencies {
+			if dep == ns {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}

--- a/internal/app/arrow/lifecycle_test.go
+++ b/internal/app/arrow/lifecycle_test.go
@@ -1,0 +1,388 @@
+package arrow
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	domainRuntime "github.com/rabbytesoftware/quiver/internal/domain/runtime"
+	"github.com/rabbytesoftware/quiver/internal/engine/deptree"
+	"github.com/rabbytesoftware/quiver/internal/engine/vault"
+	"github.com/rabbytesoftware/quiver/internal/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// trackingVault wraps mocks.Vault and records DeleteArrow calls.
+type trackingVault struct {
+	mocks.Vault
+	deletedNamespaces []domain.Namespace
+}
+
+func (v *trackingVault) DeleteArrow(_ context.Context, ns domain.Namespace) error {
+	v.deletedNamespaces = append(v.deletedNamespaces, ns)
+	return nil
+}
+
+func (v *trackingVault) GetArrow(_ context.Context, _ domain.Namespace) (*vault.VaultEntry, string, error) {
+	return v.GetArrowEntry, v.GetArrowPath, v.GetArrowErr
+}
+
+// vaultByNamespace is a test vault that returns different entries per namespace.
+type vaultByNamespace struct {
+	entries    map[domain.Namespace]*vault.VaultEntry
+	deletedNSs []domain.Namespace
+}
+
+func (v *vaultByNamespace) GetArrow(_ context.Context, ns domain.Namespace) (*vault.VaultEntry, string, error) {
+	entry, ok := v.entries[ns]
+	if !ok {
+		return nil, "", vault.ErrNotCached
+	}
+	return entry, "/home/" + ns.String(), nil
+}
+
+func (v *vaultByNamespace) PutArrow(_ context.Context, _ domain.Namespace, _ *domain.ArrowManifest, _ []domain.Namespace) (string, error) {
+	return "/home/test", nil
+}
+
+func (v *vaultByNamespace) GetQuiver(_ context.Context, _ domain.Namespace) (*vault.QuiverVaultEntry, string, error) {
+	return nil, "", vault.ErrNotCached
+}
+
+func (v *vaultByNamespace) PutQuiver(_ context.Context, _ domain.Namespace, _ *domain.QuiverManifest) (string, error) {
+	return "", nil
+}
+
+func (v *vaultByNamespace) DeleteArrow(_ context.Context, ns domain.Namespace) error {
+	v.deletedNSs = append(v.deletedNSs, ns)
+	return nil
+}
+
+func (v *vaultByNamespace) DeleteQuiver(_ context.Context, _ domain.Namespace) error {
+	return nil
+}
+
+// --- Install tests ---
+
+func TestRunInstall_NoDeps_InstallsRoot(t *testing.T) {
+	ns := domain.Namespace("github.com/org/root")
+	manifest := &domain.ArrowManifest{
+		Name:    "Root",
+		Version: "1.0.0",
+	}
+
+	mv := &mocks.Vault{
+		GetArrowEntry: &vault.VaultEntry{Manifest: manifest},
+		GetArrowPath:  "/home/root",
+	}
+	mm := &mocks.Manifold{}
+	svc := testArrowService(t, mv, mm)
+	mw := &mocks.Wizard{}
+	svc.wizard = mw
+	svc.deptree = mocks.DepTree([]domain.Namespace{ns}, nil)
+
+	addArrowForTest(t, svc, ns, manifest)
+
+	svc.runInstall(context.Background(), ns, nil)
+	svc.asynxRuntime.WaitPublish()
+
+	rt, err := svc.asynxRuntime.Get(context.Background(), ns.String())
+	require.NoError(t, err)
+	assert.Equal(t, domain.ArrowStateReady, rt.State)
+	assert.True(t, mw.WasExecuteCalled())
+}
+
+func TestRunInstall_DepInstallFails_RollsBack(t *testing.T) {
+	ns := domain.Namespace("github.com/org/root")
+	depNs := domain.Namespace("github.com/org/dep")
+
+	depManifest := &domain.ArrowManifest{Name: "Dep", Version: "1.0.0"}
+	rootManifest := &domain.ArrowManifest{
+		Name:         "Root",
+		Version:      "1.0.0",
+		Dependencies: []domain.Namespace{depNs},
+	}
+
+	mv := &mocks.Vault{
+		GetArrowEntry: &vault.VaultEntry{Manifest: rootManifest},
+		GetArrowPath:  "/home/root",
+	}
+	mm := &mocks.Manifold{ResolveArrowManifest: depManifest}
+	svc := testArrowService(t, mv, mm)
+
+	callCount := 0
+	mw := &mocks.Wizard{}
+	mw.ExecuteErr = errors.New("dep install failed")
+	svc.wizard = mw
+
+	svc.deptree = func(ctx context.Context, root domain.Namespace, resolver deptree.ResolverFunc) ([]domain.Namespace, error) {
+		callCount++
+		return []domain.Namespace{depNs, root}, nil
+	}
+
+	addArrowForTest(t, svc, ns, rootManifest)
+	addArrowForTest(t, svc, depNs, depManifest)
+
+	svc.runInstall(context.Background(), ns, nil)
+
+	rt, err := svc.asynxRuntime.Get(context.Background(), ns.String())
+	require.NoError(t, err)
+	assert.Equal(t, domain.ArrowStateAbsent, rt.State)
+}
+
+func TestInstall_ArrowNotFound_ReturnsError(t *testing.T) {
+	mv := &mocks.Vault{GetArrowErr: vault.ErrNotCached}
+	svc := testArrowService(t, mv, &mocks.Manifold{})
+
+	err := svc.Install(context.Background(), "github.com/org/repo", nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestInstall_AlreadyInstalled_ReturnsStateViolation(t *testing.T) {
+	ns := domain.Namespace("github.com/org/repo")
+	manifest := &domain.ArrowManifest{Name: "A", Version: "1.0.0"}
+
+	mv := &mocks.Vault{
+		GetArrowEntry: &vault.VaultEntry{Manifest: manifest},
+		GetArrowPath:  "/home/a",
+	}
+	svc := testArrowService(t, mv, &mocks.Manifold{})
+
+	addArrowForTest(t, svc, ns, manifest)
+
+	require.NoError(t, svc.asynxRuntime.Send(context.Background(), mocks.RuntimeCmd{
+		NS:    ns,
+		State: domain.ArrowStateReady,
+	}))
+	svc.asynxRuntime.WaitPublish()
+
+	err := svc.Install(context.Background(), ns, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrStateViolation)
+}
+
+func TestInstall_ValidArrow_LaunchesGoroutine(t *testing.T) {
+	ns := domain.Namespace("github.com/org/repo")
+	manifest := &domain.ArrowManifest{Name: "A", Version: "1.0.0"}
+
+	mv := &mocks.Vault{
+		GetArrowEntry: &vault.VaultEntry{Manifest: manifest},
+		GetArrowPath:  "/home/a",
+	}
+	mm := &mocks.Manifold{}
+	svc := testArrowService(t, mv, mm)
+
+	mw := &mocks.Wizard{}
+	svc.wizard = mw
+	svc.deptree = mocks.DepTree([]domain.Namespace{ns}, nil)
+
+	addArrowForTest(t, svc, ns, manifest)
+
+	err := svc.Install(context.Background(), ns, nil)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		rt, getErr := svc.asynxRuntime.Get(context.Background(), ns.String())
+		if getErr != nil {
+			return false
+		}
+		return rt.State == domain.ArrowStateReady || rt.State == domain.ArrowStateAbsent
+	}, 10*time.Second, 20*time.Millisecond)
+
+	rt, err := svc.asynxRuntime.Get(context.Background(), ns.String())
+	require.NoError(t, err)
+	assert.Equal(t, domain.ArrowStateReady, rt.State)
+}
+
+func TestRunInstall_DeptreeFails_EndsWithFailed(t *testing.T) {
+	ns := domain.Namespace("github.com/org/root")
+	manifest := &domain.ArrowManifest{Name: "Root", Version: "1.0.0"}
+
+	mv := &mocks.Vault{
+		GetArrowEntry: &vault.VaultEntry{Manifest: manifest},
+		GetArrowPath:  "/home/root",
+	}
+	svc := testArrowService(t, mv, &mocks.Manifold{})
+	svc.wizard = &mocks.Wizard{}
+	svc.deptree = mocks.DepTree(nil, errors.New("cycle detected"))
+
+	addArrowForTest(t, svc, ns, manifest)
+
+	svc.runInstall(context.Background(), ns, nil)
+
+	rt, err := svc.asynxRuntime.Get(context.Background(), ns.String())
+	require.NoError(t, err)
+	assert.Equal(t, domain.ArrowStateAbsent, rt.State)
+
+	require.NotNil(t, rt.LastReturn)
+	assert.Equal(t, domainRuntime.ExecutionOutcomeFailed, rt.LastReturn.Outcome)
+}
+
+// --- Uninstall tests ---
+
+func TestRunUninstall_NoOrphans_CleanupVault(t *testing.T) {
+	ns := domain.Namespace("github.com/org/root")
+	manifest := &domain.ArrowManifest{Name: "Root", Version: "1.0.0"}
+
+	tv := &trackingVault{
+		Vault: mocks.Vault{
+			GetArrowEntry: &vault.VaultEntry{Manifest: manifest},
+			GetArrowPath:  "/home/root",
+		},
+	}
+	mm := &mocks.Manifold{}
+	svc := testArrowService(t, tv, mm)
+
+	mw := &mocks.Wizard{}
+	svc.wizard = mw
+	svc.deptree = mocks.DepTree([]domain.Namespace{ns}, nil)
+
+	addArrowForTest(t, svc, ns, manifest)
+
+	require.NoError(t, svc.asynxRuntime.Send(context.Background(), mocks.RuntimeCmd{
+		NS:    ns,
+		State: domain.ArrowStateReady,
+	}))
+	svc.asynxRuntime.WaitPublish()
+
+	svc.runUninstall(context.Background(), ns, nil)
+
+	rt, err := svc.asynxRuntime.Get(context.Background(), ns.String())
+	require.NoError(t, err)
+	assert.Equal(t, domain.ArrowStateAbsent, rt.State)
+
+	assert.Contains(t, tv.deletedNamespaces, ns)
+}
+
+func TestHasDependents_NoOtherArrows_ReturnsFalse(t *testing.T) {
+	ns := domain.Namespace("github.com/org/dep")
+
+	mv := &mocks.Vault{GetArrowErr: vault.ErrNotCached}
+	svc := testArrowService(t, mv, &mocks.Manifold{})
+
+	hasDeps, err := svc.hasDependents(context.Background(), ns, "")
+	require.NoError(t, err)
+	assert.False(t, hasDeps)
+}
+
+func TestHasDependents_OtherArrowDependsOnIt_ReturnsTrue(t *testing.T) {
+	depNs := domain.Namespace("github.com/org/dep")
+	rootNs := domain.Namespace("github.com/org/root")
+
+	rootManifest := &domain.ArrowManifest{
+		Name:         "Root",
+		Version:      "1.0.0",
+		Dependencies: []domain.Namespace{depNs},
+	}
+
+	mv := &vaultByNamespace{
+		entries: map[domain.Namespace]*vault.VaultEntry{
+			rootNs: {Manifest: rootManifest},
+		},
+	}
+	svc := testArrowService(t, mv, &mocks.Manifold{})
+
+	require.NoError(t, svc.catalog.Save(domain.Arrow{Namespace: rootNs, Manifest: *rootManifest}))
+
+	require.NoError(t, svc.asynxRuntime.Send(context.Background(), mocks.RuntimeCmd{
+		NS:    rootNs,
+		State: domain.ArrowStateReady,
+	}))
+	svc.asynxRuntime.WaitPublish()
+
+	hasDeps, err := svc.hasDependents(context.Background(), depNs, "")
+	require.NoError(t, err)
+	assert.True(t, hasDeps)
+}
+
+func TestUninstall_NotReady_ReturnsStateViolation(t *testing.T) {
+	ns := domain.Namespace("github.com/org/repo")
+
+	mv := &mocks.Vault{GetArrowErr: vault.ErrNotCached}
+	svc := testArrowService(t, mv, &mocks.Manifold{})
+
+	err := svc.Uninstall(context.Background(), ns, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrStateViolation)
+}
+
+func TestUninstall_HasDependents_ReturnsError(t *testing.T) {
+	depNs := domain.Namespace("github.com/org/dep")
+	rootNs := domain.Namespace("github.com/org/root")
+
+	rootManifest := &domain.ArrowManifest{
+		Name:         "Root",
+		Version:      "1.0.0",
+		Dependencies: []domain.Namespace{depNs},
+	}
+	depManifest := &domain.ArrowManifest{Name: "Dep", Version: "1.0.0"}
+
+	mv := &vaultByNamespace{
+		entries: map[domain.Namespace]*vault.VaultEntry{
+			rootNs: {Manifest: rootManifest},
+			depNs:  {Manifest: depManifest},
+		},
+	}
+	svc := testArrowService(t, mv, &mocks.Manifold{})
+
+	require.NoError(t, svc.catalog.Save(domain.Arrow{Namespace: rootNs, Manifest: *rootManifest}))
+	require.NoError(t, svc.catalog.Save(domain.Arrow{Namespace: depNs, Manifest: *depManifest}))
+
+	require.NoError(t, svc.asynxRuntime.Send(context.Background(), mocks.RuntimeCmd{
+		NS:    rootNs,
+		State: domain.ArrowStateReady,
+	}))
+	svc.asynxRuntime.WaitPublish()
+	require.NoError(t, svc.asynxRuntime.Send(context.Background(), mocks.RuntimeCmd{
+		NS:    depNs,
+		State: domain.ArrowStateReady,
+	}))
+	svc.asynxRuntime.WaitPublish()
+
+	err := svc.Uninstall(context.Background(), depNs, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrDependentsExist)
+}
+
+func TestUninstall_ValidReady_LaunchesGoroutine(t *testing.T) {
+	ns := domain.Namespace("github.com/org/repo")
+	manifest := &domain.ArrowManifest{Name: "A", Version: "1.0.0"}
+
+	tv := &trackingVault{
+		Vault: mocks.Vault{
+			GetArrowEntry: &vault.VaultEntry{Manifest: manifest},
+			GetArrowPath:  "/home/a",
+		},
+	}
+	svc := testArrowService(t, tv, &mocks.Manifold{})
+	mw := &mocks.Wizard{}
+	svc.wizard = mw
+	svc.deptree = mocks.DepTree([]domain.Namespace{ns}, nil)
+
+	addArrowForTest(t, svc, ns, manifest)
+
+	require.NoError(t, svc.asynxRuntime.Send(context.Background(), mocks.RuntimeCmd{
+		NS:    ns,
+		State: domain.ArrowStateReady,
+	}))
+	svc.asynxRuntime.WaitPublish()
+
+	err := svc.Uninstall(context.Background(), ns, nil)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		rt, getErr := svc.asynxRuntime.Get(context.Background(), ns.String())
+		if getErr != nil {
+			return false
+		}
+		return rt.State == domain.ArrowStateAbsent
+	}, 10*time.Second, 20*time.Millisecond)
+
+	rt, err := svc.asynxRuntime.Get(context.Background(), ns.String())
+	require.NoError(t, err)
+	assert.Equal(t, domain.ArrowStateAbsent, rt.State)
+}

--- a/internal/app/arrow/projections/arrow_events.go
+++ b/internal/app/arrow/projections/arrow_events.go
@@ -1,0 +1,27 @@
+package projections
+
+import (
+	"context"
+
+	asynxModels "github.com/char2cs/asynx/models"
+	arrowstore "github.com/rabbytesoftware/quiver/internal/app/arrow/store"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+)
+
+func OnArrowAdded(catalog arrowstore.ArrowCatalog) func(context.Context, asynxModels.Event[domain.Arrow]) {
+	return func(_ context.Context, evt asynxModels.Event[domain.Arrow]) {
+		catalog.Save(evt.Aggregate)
+	}
+}
+
+func OnArrowUpdated(catalog arrowstore.ArrowCatalog) func(context.Context, asynxModels.Event[domain.Arrow]) {
+	return func(_ context.Context, evt asynxModels.Event[domain.Arrow]) {
+		catalog.Save(evt.Aggregate)
+	}
+}
+
+func OnArrowRemoved(catalog arrowstore.ArrowCatalog) func(context.Context, asynxModels.Event[domain.Arrow]) {
+	return func(_ context.Context, evt asynxModels.Event[domain.Arrow]) {
+		catalog.Delete(evt.Aggregate.Namespace)
+	}
+}

--- a/internal/app/arrow/projections/arrow_events_test.go
+++ b/internal/app/arrow/projections/arrow_events_test.go
@@ -1,0 +1,91 @@
+package projections
+
+import (
+	"context"
+	"testing"
+
+	asynxModels "github.com/char2cs/asynx/models"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockArrowCatalog struct {
+	saved   []domain.Arrow
+	deleted []domain.Namespace
+}
+
+func (m *mockArrowCatalog) Save(a domain.Arrow) error {
+	m.saved = append(m.saved, a)
+	return nil
+}
+
+func (m *mockArrowCatalog) Delete(ns domain.Namespace) error {
+	m.deleted = append(m.deleted, ns)
+	return nil
+}
+
+func (m *mockArrowCatalog) Get(_ domain.Namespace) (*domain.Arrow, error) {
+	return nil, nil
+}
+
+func (m *mockArrowCatalog) List() ([]domain.Arrow, error) {
+	return m.saved, nil
+}
+
+func TestOnArrowAdded_CallsCatalogSave(t *testing.T) {
+	catalog := &mockArrowCatalog{}
+	handler := OnArrowAdded(catalog)
+
+	arrow := domain.Arrow{
+		Namespace: "github.com/org/repo",
+		Manifest:  domain.ArrowManifest{Name: "Test", Version: "1.0.0"},
+	}
+	evt := asynxModels.Event[domain.Arrow]{
+		EventName: "arrow.added",
+		Aggregate: arrow,
+	}
+
+	handler(context.Background(), evt)
+
+	require.Len(t, catalog.saved, 1)
+	assert.Equal(t, arrow, catalog.saved[0])
+}
+
+func TestOnArrowUpdated_CallsCatalogSave(t *testing.T) {
+	catalog := &mockArrowCatalog{}
+	handler := OnArrowUpdated(catalog)
+
+	arrow := domain.Arrow{
+		Namespace: "github.com/org/repo",
+		Manifest:  domain.ArrowManifest{Name: "Updated", Version: "2.0.0"},
+	}
+	evt := asynxModels.Event[domain.Arrow]{
+		EventName: "arrow.updated",
+		Aggregate: arrow,
+	}
+
+	handler(context.Background(), evt)
+
+	require.Len(t, catalog.saved, 1)
+	assert.Equal(t, arrow, catalog.saved[0])
+}
+
+func TestOnArrowRemoved_CallsCatalogDelete(t *testing.T) {
+	catalog := &mockArrowCatalog{}
+	handler := OnArrowRemoved(catalog)
+
+	arrow := domain.Arrow{
+		Namespace: "github.com/org/repo",
+		Removed:   true,
+	}
+	evt := asynxModels.Event[domain.Arrow]{
+		EventName: "arrow.removed",
+		Aggregate: arrow,
+	}
+
+	handler(context.Background(), evt)
+
+	require.Len(t, catalog.deleted, 1)
+	assert.Equal(t, domain.Namespace("github.com/org/repo"), catalog.deleted[0])
+}

--- a/internal/app/arrow/projections/stop_coordinator.go
+++ b/internal/app/arrow/projections/stop_coordinator.go
@@ -1,1 +1,28 @@
 package projections
+
+import (
+	"context"
+
+	asynxModels "github.com/char2cs/asynx/models"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	domainRuntime "github.com/rabbytesoftware/quiver/internal/domain/runtime"
+)
+
+// wizardCanceller is satisfied by wizard.Wizard without importing it.
+type wizardCanceller interface {
+	Cancel(ns domain.Namespace)
+}
+
+func StopCoordinator(wiz wizardCanceller) func(
+	context.Context,
+	asynxModels.Event[domainRuntime.ArrowRuntime],
+) {
+	return func(
+		_ context.Context,
+		evt asynxModels.Event[domainRuntime.ArrowRuntime],
+	) {
+		if evt.EventName == "runtime.mark_stopping" {
+			wiz.Cancel(evt.Aggregate.Namespace)
+		}
+	}
+}

--- a/internal/app/arrow/projections/stop_coordinator_test.go
+++ b/internal/app/arrow/projections/stop_coordinator_test.go
@@ -1,0 +1,58 @@
+package projections
+
+import (
+	"context"
+	"testing"
+
+	asynxModels "github.com/char2cs/asynx/models"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	domainRuntime "github.com/rabbytesoftware/quiver/internal/domain/runtime"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockStopWizard struct {
+	cancelled []domain.Namespace
+}
+
+func (m *mockStopWizard) Cancel(ns domain.Namespace) {
+	m.cancelled = append(m.cancelled, ns)
+}
+
+func TestStopCoordinator_OnMarkStopping_CallsWizardCancel(t *testing.T) {
+	wiz := &mockStopWizard{}
+	handler := StopCoordinator(wiz)
+
+	ns := domain.Namespace("github.com/org/repo")
+	rt := domainRuntime.ArrowRuntime{
+		Namespace: ns,
+		State:     domain.ArrowStateStopping,
+	}
+	evt := asynxModels.Event[domainRuntime.ArrowRuntime]{
+		EventName: "runtime.mark_stopping",
+		Aggregate: rt,
+	}
+
+	handler(context.Background(), evt)
+
+	assert.Len(t, wiz.cancelled, 1)
+	assert.Equal(t, ns, wiz.cancelled[0])
+}
+
+func TestStopCoordinator_OnOtherEvent_DoesNotCallCancel(t *testing.T) {
+	wiz := &mockStopWizard{}
+	handler := StopCoordinator(wiz)
+
+	ns := domain.Namespace("github.com/org/repo")
+	rt := domainRuntime.ArrowRuntime{
+		Namespace: ns,
+		State:     domain.ArrowStateRunning,
+	}
+	evt := asynxModels.Event[domainRuntime.ArrowRuntime]{
+		EventName: "runtime.begun",
+		Aggregate: rt,
+	}
+
+	handler(context.Background(), evt)
+
+	assert.Empty(t, wiz.cancelled)
+}

--- a/internal/app/arrow/projections/websocket_arrow.go
+++ b/internal/app/arrow/projections/websocket_arrow.go
@@ -1,1 +1,0 @@
-package projections

--- a/internal/app/arrow/projections/websocket_runtime.go
+++ b/internal/app/arrow/projections/websocket_runtime.go
@@ -1,1 +1,0 @@
-package projections

--- a/internal/app/arrow/service.go
+++ b/internal/app/arrow/service.go
@@ -1,1 +1,0 @@
-package arrow

--- a/internal/app/arrow/stepreporter/step_reporter.go
+++ b/internal/app/arrow/stepreporter/step_reporter.go
@@ -1,0 +1,63 @@
+package stepreporter
+
+import (
+	"context"
+
+	"github.com/char2cs/asynx"
+	arrowcmds "github.com/rabbytesoftware/quiver/internal/app/arrow/commands"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	domainRuntime "github.com/rabbytesoftware/quiver/internal/domain/runtime"
+)
+
+type StepReporter struct {
+	asynxRuntime asynx.Asynx[domainRuntime.ArrowRuntime]
+	namespace    domain.Namespace
+	indexOffset  int
+}
+
+func New(
+	asynxRuntime asynx.Asynx[domainRuntime.ArrowRuntime],
+	namespace domain.Namespace,
+	indexOffset int,
+) *StepReporter {
+	return &StepReporter{
+		asynxRuntime: asynxRuntime,
+		namespace:    namespace,
+		indexOffset:  indexOffset,
+	}
+}
+
+func (r *StepReporter) OnStepStarted(i int) {
+	_ = r.asynxRuntime.Send(
+		context.Background(),
+		arrowcmds.AdvanceStep{
+			Namespace: r.namespace,
+			StepIndex: i + r.indexOffset,
+			ToStatus:  domainRuntime.StepStatusRunning,
+		},
+	)
+}
+
+func (r *StepReporter) OnStepCompleted(i int) {
+	_ = r.asynxRuntime.Send(
+		context.Background(),
+		arrowcmds.AdvanceStep{
+			Namespace: r.namespace,
+			StepIndex: i + r.indexOffset,
+			ToStatus:  domainRuntime.StepStatusCompleted,
+		},
+	)
+}
+
+func (r *StepReporter) OnStepFailed(i int, err error) {
+	errStr := err.Error()
+	_ = r.asynxRuntime.Send(
+		context.Background(),
+		arrowcmds.AdvanceStep{
+			Namespace: r.namespace,
+			StepIndex: i + r.indexOffset,
+			ToStatus:  domainRuntime.StepStatusFailed,
+			Error:     &errStr,
+		},
+	)
+}

--- a/internal/app/arrow/stepreporter/step_reporter_test.go
+++ b/internal/app/arrow/stepreporter/step_reporter_test.go
@@ -1,0 +1,104 @@
+package stepreporter_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/char2cs/asynx"
+	sqlite "github.com/rabbytesoftware/quiver/internal/adapter/eventstore/sqlite"
+	"github.com/rabbytesoftware/quiver/internal/app/arrow/stepreporter"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	domainRuntime "github.com/rabbytesoftware/quiver/internal/domain/runtime"
+	"github.com/rabbytesoftware/quiver/internal/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func buildAsynxRuntime(t *testing.T) asynx.Asynx[domainRuntime.ArrowRuntime] {
+	t.Helper()
+	es, err := sqlite.NewEventStore(":memory:")
+	require.NoError(t, err)
+	ax, err := asynx.New[domainRuntime.ArrowRuntime]().
+		WithEventStore(es).
+		WithShardingOpts(asynx.ShardingOpts{Shards: 8, QueueDepth: 1000}).
+		Build()
+	require.NoError(t, err)
+	return ax
+}
+
+func seedRuntime(t *testing.T, ax asynx.Asynx[domainRuntime.ArrowRuntime], ns domain.Namespace) {
+	t.Helper()
+	require.NoError(t, ax.Send(context.Background(), mocks.RuntimeCmdWithExecution{
+		NS:    ns,
+		State: domain.ArrowStateRunning,
+		ActiveRun: &domainRuntime.RunRecord{
+			Method: "_execute",
+			Steps: []domainRuntime.StepProgress{
+				{Index: 0, Status: domainRuntime.StepStatusPending},
+				{Index: 1, Status: domainRuntime.StepStatusPending},
+			},
+		},
+	}))
+	ax.WaitPublish()
+}
+
+func TestStepReporter_OnStepStarted_SendsRunningStatus(t *testing.T) {
+	ax := buildAsynxRuntime(t)
+	ns := domain.Namespace("github.com/test/arrow1")
+	seedRuntime(t, ax, ns)
+
+	r := stepreporter.New(ax, ns, 0)
+	r.OnStepStarted(0)
+	ax.WaitPublish()
+
+	rt, err := ax.Get(context.Background(), ns.String())
+	require.NoError(t, err)
+	require.NotNil(t, rt.ActiveRun)
+	assert.Equal(t, domainRuntime.StepStatusRunning, rt.ActiveRun.Steps[0].Status)
+}
+
+func TestStepReporter_OnStepCompleted_SendsCompletedStatus(t *testing.T) {
+	ax := buildAsynxRuntime(t)
+	ns := domain.Namespace("github.com/test/arrow1")
+	seedRuntime(t, ax, ns)
+
+	r := stepreporter.New(ax, ns, 0)
+	r.OnStepCompleted(1)
+	ax.WaitPublish()
+
+	rt, err := ax.Get(context.Background(), ns.String())
+	require.NoError(t, err)
+	assert.Equal(t, domainRuntime.StepStatusCompleted, rt.ActiveRun.Steps[1].Status)
+}
+
+func TestStepReporter_OnStepFailed_SendsFailedStatusWithError(t *testing.T) {
+	ax := buildAsynxRuntime(t)
+	ns := domain.Namespace("github.com/test/arrow1")
+	seedRuntime(t, ax, ns)
+
+	r := stepreporter.New(ax, ns, 0)
+	r.OnStepFailed(0, fmt.Errorf("something broke"))
+	ax.WaitPublish()
+
+	rt, err := ax.Get(context.Background(), ns.String())
+	require.NoError(t, err)
+	require.NotNil(t, rt.ActiveRun.Steps[0].Error)
+	assert.Equal(t, "something broke", *rt.ActiveRun.Steps[0].Error)
+	assert.Equal(t, domainRuntime.StepStatusFailed, rt.ActiveRun.Steps[0].Status)
+}
+
+func TestStepReporter_IndexOffset_ShiftsStepIndex(t *testing.T) {
+	ax := buildAsynxRuntime(t)
+	ns := domain.Namespace("github.com/test/arrow1")
+	seedRuntime(t, ax, ns)
+
+	r := stepreporter.New(ax, ns, 1) // offset 1: step 0 from wizard → index 1 in aggregate
+	r.OnStepCompleted(0)
+	ax.WaitPublish()
+
+	rt, err := ax.Get(context.Background(), ns.String())
+	require.NoError(t, err)
+	assert.Equal(t, domainRuntime.StepStatusCompleted, rt.ActiveRun.Steps[1].Status)
+	assert.Equal(t, domainRuntime.StepStatusPending, rt.ActiveRun.Steps[0].Status)
+}

--- a/internal/app/arrow/store/store.go
+++ b/internal/app/arrow/store/store.go
@@ -1,0 +1,147 @@
+package store
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/rabbytesoftware/quiver/internal/core/metadata"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	_ "modernc.org/sqlite"
+)
+
+type ArrowCatalog interface {
+	Save(arrow domain.Arrow) error
+	Delete(ns domain.Namespace) error
+	Get(ns domain.Namespace) (*domain.Arrow, error)
+	List() ([]domain.Arrow, error)
+}
+
+type arrowRow struct {
+	Namespace string `db:"namespace"`
+	Manifest  string `db:"manifest"`
+	Removed   bool   `db:"removed"`
+}
+
+type arrowCatalog struct {
+	db *sqlx.DB
+	mu sync.RWMutex
+}
+
+func NewArrowCatalog() (ArrowCatalog, error) {
+	return NewArrowCatalogFromPath(metadata.GetQuiverHome() + "/arrows.db")
+}
+
+func NewArrowCatalogFromPath(path string) (ArrowCatalog, error) {
+	db, err := sqlx.Open("sqlite", path)
+	if err != nil {
+		return nil, fmt.Errorf("arrow catalog: open: %w", err)
+	}
+
+	_, err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS arrows (
+			namespace TEXT PRIMARY KEY,
+			manifest TEXT NOT NULL,
+			removed INTEGER NOT NULL DEFAULT 0
+		)
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("arrow catalog: schema: %w", err)
+	}
+
+	return &arrowCatalog{db: db}, nil
+}
+
+func (ac *arrowCatalog) Save(arrow domain.Arrow) error {
+	ac.mu.Lock()
+	defer ac.mu.Unlock()
+
+	manifestJSON, err := json.Marshal(arrow.Manifest)
+	if err != nil {
+		return err
+	}
+
+	row := arrowRow{
+		Namespace: arrow.Namespace.String(),
+		Manifest:  string(manifestJSON),
+		Removed:   arrow.Removed,
+	}
+
+	_, err = ac.db.NamedExec(
+		`INSERT OR REPLACE INTO arrows (namespace, manifest, removed) VALUES (:namespace, :manifest, :removed)`,
+		row,
+	)
+	if err != nil {
+		return fmt.Errorf("arrow catalog: save: %w", err)
+	}
+
+	return nil
+}
+
+func (ac *arrowCatalog) Delete(ns domain.Namespace) error {
+	ac.mu.Lock()
+	defer ac.mu.Unlock()
+
+	_, err := ac.db.Exec(`DELETE FROM arrows WHERE namespace = ?`, ns.String())
+	if err != nil {
+		return fmt.Errorf("arrow catalog: delete: %w", err)
+	}
+
+	return nil
+}
+
+func (ac *arrowCatalog) Get(ns domain.Namespace) (*domain.Arrow, error) {
+	ac.mu.RLock()
+	defer ac.mu.RUnlock()
+
+	var row arrowRow
+	err := ac.db.Get(&row, `SELECT namespace, manifest, removed FROM arrows WHERE namespace = ?`, ns.String())
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var manifest domain.ArrowManifest
+	err = json.Unmarshal([]byte(row.Manifest), &manifest)
+	if err != nil {
+		return nil, err
+	}
+
+	return &domain.Arrow{
+		Namespace: domain.Namespace(row.Namespace),
+		Manifest:  manifest,
+		Removed:   row.Removed,
+	}, nil
+}
+
+func (ac *arrowCatalog) List() ([]domain.Arrow, error) {
+	ac.mu.RLock()
+	defer ac.mu.RUnlock()
+
+	var rows []arrowRow
+	err := ac.db.Select(&rows, `SELECT namespace, manifest, removed FROM arrows`)
+	if err != nil {
+		return nil, err
+	}
+
+	arrows := make([]domain.Arrow, 0, len(rows))
+	for _, row := range rows {
+		var manifest domain.ArrowManifest
+		err := json.Unmarshal([]byte(row.Manifest), &manifest)
+		if err != nil {
+			return nil, err
+		}
+
+		arrows = append(arrows, domain.Arrow{
+			Namespace: domain.Namespace(row.Namespace),
+			Manifest:  manifest,
+			Removed:   row.Removed,
+		})
+	}
+
+	return arrows, nil
+}

--- a/internal/app/arrow/store/store_test.go
+++ b/internal/app/arrow/store/store_test.go
@@ -1,0 +1,91 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeTestArrow(ns string, name string) domain.Arrow {
+	return domain.Arrow{
+		Namespace: domain.Namespace(ns),
+		Manifest: domain.ArrowManifest{
+			Name:    name,
+			Version: "1.0.0",
+		},
+		Removed: false,
+	}
+}
+
+func TestArrowCatalog_SaveAndGet_ReturnsSavedArrow(t *testing.T) {
+	c, err := NewArrowCatalogFromPath(":memory:")
+	require.NoError(t, err)
+
+	arrow := makeTestArrow("github.com/org/repo", "MyArrow")
+
+	err = c.Save(arrow)
+	require.NoError(t, err)
+
+	got, err := c.Get(arrow.Namespace)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, arrow.Namespace, got.Namespace)
+	assert.Equal(t, arrow.Manifest.Name, got.Manifest.Name)
+	assert.Equal(t, arrow.Manifest.Version, got.Manifest.Version)
+	assert.Equal(t, arrow.Removed, got.Removed)
+}
+
+func TestArrowCatalog_SaveDeleteGet_ReturnsNil(t *testing.T) {
+	c, err := NewArrowCatalogFromPath(":memory:")
+	require.NoError(t, err)
+
+	arrow := makeTestArrow("github.com/org/repo", "MyArrow")
+
+	err = c.Save(arrow)
+	require.NoError(t, err)
+
+	err = c.Delete(arrow.Namespace)
+	require.NoError(t, err)
+
+	got, err := c.Get(arrow.Namespace)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestArrowCatalog_List_ReturnsAllSaved(t *testing.T) {
+	c, err := NewArrowCatalogFromPath(":memory:")
+	require.NoError(t, err)
+
+	a1 := makeTestArrow("github.com/org/repo1", "Arrow1")
+	a2 := makeTestArrow("github.com/org/repo2", "Arrow2")
+
+	require.NoError(t, c.Save(a1))
+	require.NoError(t, c.Save(a2))
+
+	arrows, err := c.List()
+	require.NoError(t, err)
+	assert.Len(t, arrows, 2)
+
+	namespaces := make([]domain.Namespace, 0, len(arrows))
+	for _, a := range arrows {
+		namespaces = append(namespaces, a.Namespace)
+	}
+	assert.Contains(t, namespaces, a1.Namespace)
+	assert.Contains(t, namespaces, a2.Namespace)
+}
+
+func TestArrowCatalog_ListAfterRemove_ReturnsEmpty(t *testing.T) {
+	c, err := NewArrowCatalogFromPath(":memory:")
+	require.NoError(t, err)
+
+	arrow := makeTestArrow("github.com/org/repo", "MyArrow")
+
+	require.NoError(t, c.Save(arrow))
+	require.NoError(t, c.Delete(arrow.Namespace))
+
+	arrows, err := c.List()
+	require.NoError(t, err)
+	assert.Empty(t, arrows)
+}

--- a/internal/app/arrow/types.go
+++ b/internal/app/arrow/types.go
@@ -1,0 +1,38 @@
+package arrow
+
+import (
+	"errors"
+
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	domainRuntime "github.com/rabbytesoftware/quiver/internal/domain/runtime"
+)
+
+var (
+	ErrNotFound         = errors.New("not found")
+	ErrAlreadyExists    = errors.New("already exists")
+	ErrAlreadyRemoved   = errors.New("already removed")
+	ErrStateViolation   = errors.New("state violation")
+	ErrFetchFailed      = errors.New("fetch failed")
+	ErrInvalidNamespace = errors.New("invalid namespace")
+	ErrDependentsExist  = errors.New("other arrows depend on this arrow")
+)
+
+type ArrowListDTO struct {
+	Namespace   domain.Namespace  `json:"namespace"`
+	Name        string            `json:"name"`
+	Version     string            `json:"version"`
+	Description string            `json:"description"`
+	State       domain.ArrowState `json:"state"`
+	Tags        []string          `json:"tags"`
+	Removed     bool              `json:"removed"`
+}
+
+type ArrowDetailDTO struct {
+	Namespace            domain.Namespace         `json:"namespace"`
+	Manifest             domain.ArrowManifest     `json:"manifest"`
+	State                domain.ArrowState        `json:"state"`
+	Removed              bool                     `json:"removed"`
+	ActiveRun            *domainRuntime.RunRecord `json:"active_run,omitempty"`
+	LastReturn           *domainRuntime.Return    `json:"last_return,omitempty"`
+	IndirectDependencies []domain.Namespace       `json:"indirect_dependencies,omitempty"`
+}

--- a/internal/app/quiver/asynx.go
+++ b/internal/app/quiver/asynx.go
@@ -1,1 +1,0 @@
-package quiver

--- a/internal/app/quiver/builder.go
+++ b/internal/app/quiver/builder.go
@@ -1,0 +1,109 @@
+package quiver
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/char2cs/asynx"
+	asynxModels "github.com/char2cs/asynx/models"
+	quiverproj "github.com/rabbytesoftware/quiver/internal/app/quiver/projections"
+	quiverstore "github.com/rabbytesoftware/quiver/internal/app/quiver/store"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	"github.com/rabbytesoftware/quiver/internal/engine/manifold"
+	"github.com/rabbytesoftware/quiver/internal/engine/vault"
+)
+
+type Builder struct {
+	eventStore asynxModels.Store
+	catalog    quiverstore.QuiverCatalog
+	vault      vault.Vault
+	manifold   manifold.Manifold
+	os         string
+}
+
+func NewQuiverBuilder() *Builder {
+	return &Builder{}
+}
+
+func (b *Builder) WithEventStore(es asynxModels.Store) *Builder {
+	b.eventStore = es
+	return b
+}
+
+func (b *Builder) WithCatalog(c quiverstore.QuiverCatalog) *Builder {
+	b.catalog = c
+	return b
+}
+
+func (b *Builder) WithVault(v vault.Vault) *Builder {
+	b.vault = v
+	return b
+}
+
+func (b *Builder) WithManifold(m manifold.Manifold) *Builder {
+	b.manifold = m
+	return b
+}
+
+func (b *Builder) WithOS(os string) *Builder {
+	b.os = os
+	return b
+}
+
+// Build constructs and returns a QuiverService
+func (b *Builder) Build(ctx context.Context) (QuiverService, error) {
+	if b.eventStore == nil {
+		return nil, fmt.Errorf("quiver builder: event store is required")
+	}
+
+	axQuiver, err := newAsynxQuiver(b.eventStore)
+	if err != nil {
+		return nil, err
+	}
+
+	catalog := b.catalog
+	if catalog == nil {
+		var err error
+		catalog, err = quiverstore.NewQuiverCatalog()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	svc := &quiverService{
+		asynxQuiver: axQuiver,
+		catalog:     catalog,
+		vault:       b.vault,
+		manifold:    b.manifold,
+		os:          b.os,
+	}
+
+	_, err = svc.asynxQuiver.Subscribe("quiver.added", quiverproj.OnQuiverAdded(catalog))
+	if err != nil {
+		return nil, err
+	}
+	_, err = svc.asynxQuiver.Subscribe("quiver.updated", quiverproj.OnQuiverUpdated(catalog))
+	if err != nil {
+		return nil, err
+	}
+	_, err = svc.asynxQuiver.Subscribe("quiver.removed", quiverproj.OnQuiverRemoved(catalog))
+	if err != nil {
+		return nil, err
+	}
+
+	return svc, nil
+}
+
+// newAsynxQuiver creates and returns a new Asynx instance for Quiver aggregates
+func newAsynxQuiver(es asynxModels.Store) (asynx.Asynx[domain.Quiver], error) {
+	if es == nil {
+		return nil, fmt.Errorf("asynx quiver: event store is required")
+	}
+
+	ax, err := asynx.New[domain.Quiver]().
+		WithEventStore(es).
+		WithShardingOpts(asynx.ShardingOpts{Shards: 8, QueueDepth: 1000}).
+		Build()
+
+	return ax, err
+}

--- a/internal/app/quiver/builder_test.go
+++ b/internal/app/quiver/builder_test.go
@@ -1,0 +1,50 @@
+package quiver
+
+import (
+	"context"
+	"testing"
+
+	sqlite "github.com/rabbytesoftware/quiver/internal/adapter/eventstore/sqlite"
+	quiverstore "github.com/rabbytesoftware/quiver/internal/app/quiver/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuilder_Build_SucceedsWithValidEventStore(t *testing.T) {
+	es, err := sqlite.NewEventStore(":memory:")
+	require.NoError(t, err)
+
+	catalog, err := quiverstore.NewQuiverCatalogFromPath(":memory:")
+	require.NoError(t, err)
+
+	svc, err := NewQuiverBuilder().
+		WithEventStore(es).
+		WithCatalog(catalog).
+		Build(context.Background())
+
+	require.NoError(t, err)
+	assert.NotNil(t, svc)
+}
+
+func TestBuilder_Build_FailsWithNilEventStore(t *testing.T) {
+	svc, err := NewQuiverBuilder().Build(context.Background())
+
+	require.Error(t, err)
+	assert.Nil(t, svc)
+}
+
+func TestBuilder_Build_UsesProvidedCatalog(t *testing.T) {
+	es, err := sqlite.NewEventStore(":memory:")
+	require.NoError(t, err)
+
+	catalog, err := quiverstore.NewQuiverCatalogFromPath(":memory:")
+	require.NoError(t, err)
+
+	svc, err := NewQuiverBuilder().
+		WithEventStore(es).
+		WithCatalog(catalog).
+		Build(context.Background())
+
+	require.NoError(t, err)
+	assert.NotNil(t, svc)
+}

--- a/internal/app/quiver/commands/add.go
+++ b/internal/app/quiver/commands/add.go
@@ -1,1 +1,40 @@
 package commands
+
+import (
+	"fmt"
+
+	asynxModels "github.com/char2cs/asynx/models"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+)
+
+type AddQuiver struct {
+	Namespace domain.Namespace
+	Manifest  domain.QuiverManifest
+}
+
+func (c AddQuiver) AggregateID() string {
+	return c.Namespace.String()
+}
+
+func (c AddQuiver) EventName() string {
+	return "quiver.added"
+}
+
+func (c AddQuiver) ShouldSnapshot() bool {
+	return false
+}
+
+func (c AddQuiver) Validate(current *domain.Quiver) error {
+	if current != nil && !current.Removed {
+		return fmt.Errorf("add quiver: %w", asynxModels.ErrValidation)
+	}
+	return nil
+}
+
+func (c AddQuiver) EmitEvent(_ *domain.Quiver) domain.Quiver {
+	return domain.Quiver{
+		Namespace: c.Namespace,
+		Manifest:  c.Manifest,
+		Removed:   false,
+	}
+}

--- a/internal/app/quiver/commands/add_test.go
+++ b/internal/app/quiver/commands/add_test.go
@@ -1,0 +1,48 @@
+package commands
+
+import (
+	"errors"
+	"testing"
+
+	asynxModels "github.com/char2cs/asynx/models"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddQuiver_AggregateID(t *testing.T) {
+	cmd := AddQuiver{Namespace: "github.com/org/repo"}
+	assert.Equal(t, "github.com/org/repo", cmd.AggregateID())
+}
+
+func TestAddQuiver_EventName(t *testing.T) {
+	assert.Equal(t, "quiver.added", AddQuiver{}.EventName())
+}
+
+func TestAddQuiver_Validate_NilState_ReturnsNil(t *testing.T) {
+	cmd := AddQuiver{Namespace: "github.com/org/repo"}
+	require.NoError(t, cmd.Validate(nil))
+}
+
+func TestAddQuiver_Validate_AlreadyExists_ReturnsValidationError(t *testing.T) {
+	cmd := AddQuiver{Namespace: "github.com/org/repo"}
+	existing := &domain.Quiver{Namespace: "github.com/org/repo", Removed: false}
+	err := cmd.Validate(existing)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, asynxModels.ErrValidation))
+}
+
+func TestAddQuiver_Validate_RemovedQuiver_ReturnsNil(t *testing.T) {
+	cmd := AddQuiver{Namespace: "github.com/org/repo"}
+	existing := &domain.Quiver{Namespace: "github.com/org/repo", Removed: true}
+	require.NoError(t, cmd.Validate(existing))
+}
+
+func TestAddQuiver_EmitEvent_ReturnsQuiver(t *testing.T) {
+	manifest := domain.QuiverManifest{Name: "Test"}
+	cmd := AddQuiver{Namespace: "github.com/org/repo", Manifest: manifest}
+	result := cmd.EmitEvent(nil)
+	assert.Equal(t, domain.Namespace("github.com/org/repo"), result.Namespace)
+	assert.Equal(t, manifest, result.Manifest)
+	assert.False(t, result.Removed)
+}

--- a/internal/app/quiver/commands/remove.go
+++ b/internal/app/quiver/commands/remove.go
@@ -1,1 +1,42 @@
 package commands
+
+import (
+	"fmt"
+
+	asynxModels "github.com/char2cs/asynx/models"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+)
+
+type RemoveQuiver struct {
+	Namespace domain.Namespace
+}
+
+func (c RemoveQuiver) AggregateID() string {
+	return c.Namespace.String()
+}
+
+func (c RemoveQuiver) EventName() string {
+	return "quiver.removed"
+}
+
+func (c RemoveQuiver) ShouldSnapshot() bool {
+	return false
+}
+
+func (c RemoveQuiver) Validate(current *domain.Quiver) error {
+	if current == nil {
+		return fmt.Errorf("remove quiver: %w", asynxModels.ErrValidation)
+	}
+	if current.Removed {
+		return fmt.Errorf("remove quiver: %w", asynxModels.ErrValidation)
+	}
+	return nil
+}
+
+func (c RemoveQuiver) EmitEvent(current *domain.Quiver) domain.Quiver {
+	return domain.Quiver{
+		Namespace: current.Namespace,
+		Manifest:  current.Manifest,
+		Removed:   true,
+	}
+}

--- a/internal/app/quiver/commands/remove_test.go
+++ b/internal/app/quiver/commands/remove_test.go
@@ -1,0 +1,48 @@
+package commands
+
+import (
+	"errors"
+	"testing"
+
+	asynxModels "github.com/char2cs/asynx/models"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoveQuiver_AggregateID(t *testing.T) {
+	cmd := RemoveQuiver{Namespace: "github.com/org/repo"}
+	assert.Equal(t, "github.com/org/repo", cmd.AggregateID())
+}
+
+func TestRemoveQuiver_EventName(t *testing.T) {
+	assert.Equal(t, "quiver.removed", RemoveQuiver{}.EventName())
+}
+
+func TestRemoveQuiver_Validate_NilState_ReturnsError(t *testing.T) {
+	cmd := RemoveQuiver{Namespace: "github.com/org/repo"}
+	err := cmd.Validate(nil)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, asynxModels.ErrValidation))
+}
+
+func TestRemoveQuiver_Validate_AlreadyRemoved_ReturnsError(t *testing.T) {
+	cmd := RemoveQuiver{Namespace: "github.com/org/repo"}
+	existing := &domain.Quiver{Namespace: "github.com/org/repo", Removed: true}
+	err := cmd.Validate(existing)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, asynxModels.ErrValidation))
+}
+
+func TestRemoveQuiver_Validate_Active_ReturnsNil(t *testing.T) {
+	cmd := RemoveQuiver{Namespace: "github.com/org/repo"}
+	existing := &domain.Quiver{Namespace: "github.com/org/repo", Removed: false}
+	require.NoError(t, cmd.Validate(existing))
+}
+
+func TestRemoveQuiver_EmitEvent_MarksRemoved(t *testing.T) {
+	existing := &domain.Quiver{Namespace: "github.com/org/repo", Removed: false}
+	cmd := RemoveQuiver{Namespace: "github.com/org/repo"}
+	result := cmd.EmitEvent(existing)
+	assert.True(t, result.Removed)
+}

--- a/internal/app/quiver/commands/update_manifest.go
+++ b/internal/app/quiver/commands/update_manifest.go
@@ -1,1 +1,43 @@
 package commands
+
+import (
+	"fmt"
+
+	asynxModels "github.com/char2cs/asynx/models"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+)
+
+type UpdateQuiverManifest struct {
+	Namespace domain.Namespace
+	Manifest  domain.QuiverManifest
+}
+
+func (c UpdateQuiverManifest) AggregateID() string {
+	return c.Namespace.String()
+}
+
+func (c UpdateQuiverManifest) EventName() string {
+	return "quiver.updated"
+}
+
+func (c UpdateQuiverManifest) ShouldSnapshot() bool {
+	return false
+}
+
+func (c UpdateQuiverManifest) Validate(current *domain.Quiver) error {
+	if current == nil {
+		return fmt.Errorf("update quiver: %w", asynxModels.ErrValidation)
+	}
+	if current.Removed {
+		return fmt.Errorf("update quiver: %w", asynxModels.ErrValidation)
+	}
+	return nil
+}
+
+func (c UpdateQuiverManifest) EmitEvent(current *domain.Quiver) domain.Quiver {
+	return domain.Quiver{
+		Namespace: current.Namespace,
+		Manifest:  c.Manifest,
+		Removed:   false,
+	}
+}

--- a/internal/app/quiver/commands/update_manifest_test.go
+++ b/internal/app/quiver/commands/update_manifest_test.go
@@ -1,0 +1,50 @@
+package commands
+
+import (
+	"errors"
+	"testing"
+
+	asynxModels "github.com/char2cs/asynx/models"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateQuiverManifest_AggregateID(t *testing.T) {
+	cmd := UpdateQuiverManifest{Namespace: "github.com/org/repo"}
+	assert.Equal(t, "github.com/org/repo", cmd.AggregateID())
+}
+
+func TestUpdateQuiverManifest_EventName(t *testing.T) {
+	assert.Equal(t, "quiver.updated", UpdateQuiverManifest{}.EventName())
+}
+
+func TestUpdateQuiverManifest_Validate_NilState_ReturnsError(t *testing.T) {
+	cmd := UpdateQuiverManifest{Namespace: "github.com/org/repo"}
+	err := cmd.Validate(nil)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, asynxModels.ErrValidation))
+}
+
+func TestUpdateQuiverManifest_Validate_Removed_ReturnsError(t *testing.T) {
+	cmd := UpdateQuiverManifest{Namespace: "github.com/org/repo"}
+	existing := &domain.Quiver{Namespace: "github.com/org/repo", Removed: true}
+	err := cmd.Validate(existing)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, asynxModels.ErrValidation))
+}
+
+func TestUpdateQuiverManifest_Validate_Active_ReturnsNil(t *testing.T) {
+	cmd := UpdateQuiverManifest{Namespace: "github.com/org/repo"}
+	existing := &domain.Quiver{Namespace: "github.com/org/repo", Removed: false}
+	require.NoError(t, cmd.Validate(existing))
+}
+
+func TestUpdateQuiverManifest_EmitEvent_UpdatesManifest(t *testing.T) {
+	newManifest := domain.QuiverManifest{Name: "Updated"}
+	existing := &domain.Quiver{Namespace: "github.com/org/repo", Removed: false}
+	cmd := UpdateQuiverManifest{Namespace: "github.com/org/repo", Manifest: newManifest}
+	result := cmd.EmitEvent(existing)
+	assert.Equal(t, newManifest, result.Manifest)
+	assert.False(t, result.Removed)
+}

--- a/internal/app/quiver/integration_test.go
+++ b/internal/app/quiver/integration_test.go
@@ -1,0 +1,251 @@
+package quiver
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	sqlite "github.com/rabbytesoftware/quiver/internal/adapter/eventstore/sqlite"
+	quiverstore "github.com/rabbytesoftware/quiver/internal/app/quiver/store"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	"github.com/rabbytesoftware/quiver/internal/engine/vault"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// integrationFixture wires a real QuiverService with mock engines.
+type integrationFixture struct {
+	svc      QuiverService
+	inner    *quiverService
+	vault    *mockIntegVault
+	manifold *mockIntegManifold
+}
+
+func newIntegrationFixture(t *testing.T) *integrationFixture {
+	t.Helper()
+
+	es, err := sqlite.NewEventStore(":memory:")
+	require.NoError(t, err)
+
+	catalog, err := quiverstore.NewQuiverCatalogFromPath(":memory:")
+	require.NoError(t, err)
+
+	v := &mockIntegVault{
+		manifests: map[string]*domain.QuiverManifest{},
+		paths:     map[string]string{},
+	}
+	m := &mockIntegManifold{manifests: map[string]*domain.QuiverManifest{}}
+
+	svc, err := NewQuiverBuilder().
+		WithEventStore(es).
+		WithCatalog(catalog).
+		WithVault(v).
+		WithManifold(m).
+		WithOS("linux").
+		Build(context.Background())
+	require.NoError(t, err)
+
+	inner := svc.(*quiverService)
+
+	return &integrationFixture{
+		svc:      svc,
+		inner:    inner,
+		vault:    v,
+		manifold: m,
+	}
+}
+
+// mockIntegVault stores quiver manifests in memory.
+type mockIntegVault struct {
+	mu        sync.Mutex
+	manifests map[string]*domain.QuiverManifest
+	paths     map[string]string
+}
+
+func (v *mockIntegVault) GetArrow(
+	_ context.Context,
+	_ domain.Namespace,
+) (*vault.VaultEntry, string, error) {
+	return nil, "", vault.ErrNotCached
+}
+
+func (v *mockIntegVault) PutArrow(
+	_ context.Context,
+	_ domain.Namespace,
+	_ *domain.ArrowManifest,
+	_ []domain.Namespace,
+) (string, error) {
+	return "", nil
+}
+
+func (v *mockIntegVault) DeleteArrow(_ context.Context, _ domain.Namespace) error {
+	return nil
+}
+
+func (v *mockIntegVault) GetQuiver(
+	_ context.Context,
+	ns domain.Namespace,
+) (*vault.QuiverVaultEntry, string, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	m, ok := v.manifests[ns.String()]
+	if !ok {
+		return nil, "", vault.ErrNotCached
+	}
+
+	return &vault.QuiverVaultEntry{Manifest: m}, v.paths[ns.String()], nil
+}
+
+func (v *mockIntegVault) PutQuiver(
+	_ context.Context,
+	ns domain.Namespace,
+	manifest *domain.QuiverManifest,
+) (string, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	key := ns.String()
+	v.manifests[key] = manifest
+	path := "/tmp/integ/" + key
+	v.paths[key] = path
+	return path, nil
+}
+
+func (v *mockIntegVault) DeleteQuiver(_ context.Context, ns domain.Namespace) error {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	key := ns.String()
+	delete(v.manifests, key)
+	delete(v.paths, key)
+	return nil
+}
+
+// mockIntegManifold returns quiver manifests keyed by namespace string.
+type mockIntegManifold struct {
+	mu        sync.Mutex
+	manifests map[string]*domain.QuiverManifest
+}
+
+func (m *mockIntegManifold) ResolveArrow(
+	_ context.Context,
+	_ domain.Namespace,
+) (*domain.ArrowManifest, error) {
+	return nil, ErrFetchFailed
+}
+
+func (m *mockIntegManifold) ResolveQuiver(
+	_ context.Context,
+	ns domain.Namespace,
+) (*domain.QuiverManifest, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	manifest, ok := m.manifests[ns.String()]
+	if !ok {
+		return nil, ErrFetchFailed
+	}
+	return manifest, nil
+}
+
+func (m *mockIntegManifold) set(ns domain.Namespace, manifest *domain.QuiverManifest) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.manifests[ns.String()] = manifest
+}
+
+// --- Integration Tests ---
+
+func TestIntegration_Add_QuiverAppearsInList(t *testing.T) {
+	f := newIntegrationFixture(t)
+	ctx := context.Background()
+
+	ns := domain.Namespace("github.com/test/quiver1")
+	f.manifold.set(ns, &domain.QuiverManifest{Name: "Quiver1"})
+
+	err := f.svc.Add(ctx, ns)
+	require.NoError(t, err)
+
+	f.inner.asynxQuiver.WaitPublish()
+
+	list, err := f.svc.List(ctx)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, ns, list[0].Namespace)
+}
+
+func TestIntegration_Update_ManifestChanges(t *testing.T) {
+	f := newIntegrationFixture(t)
+	ctx := context.Background()
+
+	ns := domain.Namespace("github.com/test/quiver1")
+	f.manifold.set(ns, &domain.QuiverManifest{Name: "Quiver1"})
+
+	require.NoError(t, f.svc.Add(ctx, ns))
+	f.inner.asynxQuiver.WaitPublish()
+
+	f.manifold.set(ns, &domain.QuiverManifest{Name: "Quiver1Updated"})
+
+	require.NoError(t, f.svc.Update(ctx, ns))
+	f.inner.asynxQuiver.WaitPublish()
+
+	detail, err := f.svc.GetDetail(ctx, ns)
+	require.NoError(t, err)
+	assert.Equal(t, "Quiver1Updated", detail.Manifest.Name)
+}
+
+func TestIntegration_Remove_DisappearsFromList(t *testing.T) {
+	f := newIntegrationFixture(t)
+	ctx := context.Background()
+
+	ns := domain.Namespace("github.com/test/quiver1")
+	f.manifold.set(ns, &domain.QuiverManifest{Name: "Quiver1"})
+
+	require.NoError(t, f.svc.Add(ctx, ns))
+	f.inner.asynxQuiver.WaitPublish()
+
+	require.NoError(t, f.svc.Remove(ctx, ns))
+	f.inner.asynxQuiver.WaitPublish()
+
+	list, err := f.svc.List(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, list)
+}
+
+func TestIntegration_AddUpdateRemoveList_FullFlow(t *testing.T) {
+	f := newIntegrationFixture(t)
+	ctx := context.Background()
+
+	ns1 := domain.Namespace("github.com/test/quiver1")
+	ns2 := domain.Namespace("github.com/test/quiver2")
+	f.manifold.set(ns1, &domain.QuiverManifest{Name: "Quiver1", Tags: []string{"tag1"}})
+	f.manifold.set(ns2, &domain.QuiverManifest{Name: "Quiver2", Tags: []string{"tag2"}})
+
+	// Add both
+	require.NoError(t, f.svc.Add(ctx, ns1))
+	require.NoError(t, f.svc.Add(ctx, ns2))
+	f.inner.asynxQuiver.WaitPublish()
+
+	list, err := f.svc.List(ctx)
+	require.NoError(t, err)
+	assert.Len(t, list, 2)
+
+	// Update ns1
+	f.manifold.set(ns1, &domain.QuiverManifest{Name: "Quiver1V2", Tags: []string{"tag1", "updated"}})
+	require.NoError(t, f.svc.Update(ctx, ns1))
+	f.inner.asynxQuiver.WaitPublish()
+
+	detail, err := f.svc.GetDetail(ctx, ns1)
+	require.NoError(t, err)
+	assert.Equal(t, "Quiver1V2", detail.Manifest.Name)
+
+	// Remove ns2
+	require.NoError(t, f.svc.Remove(ctx, ns2))
+	f.inner.asynxQuiver.WaitPublish()
+
+	list, err = f.svc.List(ctx)
+	require.NoError(t, err)
+	assert.Len(t, list, 1)
+	assert.Equal(t, ns1, list[0].Namespace)
+}

--- a/internal/app/quiver/projections/quiver_events.go
+++ b/internal/app/quiver/projections/quiver_events.go
@@ -1,0 +1,27 @@
+package projections
+
+import (
+	"context"
+
+	asynxModels "github.com/char2cs/asynx/models"
+	quiverstore "github.com/rabbytesoftware/quiver/internal/app/quiver/store"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+)
+
+func OnQuiverAdded(catalog quiverstore.QuiverCatalog) func(context.Context, asynxModels.Event[domain.Quiver]) {
+	return func(_ context.Context, evt asynxModels.Event[domain.Quiver]) {
+		catalog.Save(evt.Aggregate)
+	}
+}
+
+func OnQuiverUpdated(catalog quiverstore.QuiverCatalog) func(context.Context, asynxModels.Event[domain.Quiver]) {
+	return func(_ context.Context, evt asynxModels.Event[domain.Quiver]) {
+		catalog.Save(evt.Aggregate)
+	}
+}
+
+func OnQuiverRemoved(catalog quiverstore.QuiverCatalog) func(context.Context, asynxModels.Event[domain.Quiver]) {
+	return func(_ context.Context, evt asynxModels.Event[domain.Quiver]) {
+		catalog.Delete(evt.Aggregate.Namespace)
+	}
+}

--- a/internal/app/quiver/projections/quiver_events_test.go
+++ b/internal/app/quiver/projections/quiver_events_test.go
@@ -1,0 +1,91 @@
+package projections
+
+import (
+	"context"
+	"testing"
+
+	asynxModels "github.com/char2cs/asynx/models"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockQuiverCatalog struct {
+	saved   []domain.Quiver
+	deleted []domain.Namespace
+}
+
+func (m *mockQuiverCatalog) Save(q domain.Quiver) error {
+	m.saved = append(m.saved, q)
+	return nil
+}
+
+func (m *mockQuiverCatalog) Delete(ns domain.Namespace) error {
+	m.deleted = append(m.deleted, ns)
+	return nil
+}
+
+func (m *mockQuiverCatalog) Get(_ domain.Namespace) (*domain.Quiver, error) {
+	return nil, nil
+}
+
+func (m *mockQuiverCatalog) List() ([]domain.Quiver, error) {
+	return m.saved, nil
+}
+
+func TestOnQuiverAdded_CallsCatalogSave(t *testing.T) {
+	catalog := &mockQuiverCatalog{}
+	handler := OnQuiverAdded(catalog)
+
+	quiver := domain.Quiver{
+		Namespace: "github.com/org/repo",
+		Manifest:  domain.QuiverManifest{Name: "Test"},
+	}
+	evt := asynxModels.Event[domain.Quiver]{
+		EventName: "quiver.added",
+		Aggregate: quiver,
+	}
+
+	handler(context.Background(), evt)
+
+	require.Len(t, catalog.saved, 1)
+	assert.Equal(t, quiver, catalog.saved[0])
+}
+
+func TestOnQuiverUpdated_CallsCatalogSave(t *testing.T) {
+	catalog := &mockQuiverCatalog{}
+	handler := OnQuiverUpdated(catalog)
+
+	quiver := domain.Quiver{
+		Namespace: "github.com/org/repo",
+		Manifest:  domain.QuiverManifest{Name: "Updated"},
+	}
+	evt := asynxModels.Event[domain.Quiver]{
+		EventName: "quiver.updated",
+		Aggregate: quiver,
+	}
+
+	handler(context.Background(), evt)
+
+	require.Len(t, catalog.saved, 1)
+	assert.Equal(t, quiver, catalog.saved[0])
+}
+
+func TestOnQuiverRemoved_CallsCatalogDelete(t *testing.T) {
+	catalog := &mockQuiverCatalog{}
+	handler := OnQuiverRemoved(catalog)
+
+	quiver := domain.Quiver{
+		Namespace: "github.com/org/repo",
+		Removed:   true,
+	}
+	evt := asynxModels.Event[domain.Quiver]{
+		EventName: "quiver.removed",
+		Aggregate: quiver,
+	}
+
+	handler(context.Background(), evt)
+
+	require.Len(t, catalog.deleted, 1)
+	assert.Equal(t, domain.Namespace("github.com/org/repo"), catalog.deleted[0])
+}

--- a/internal/app/quiver/projections/websocket_quiver.go
+++ b/internal/app/quiver/projections/websocket_quiver.go
@@ -1,1 +1,0 @@
-package projections

--- a/internal/app/quiver/quiver.go
+++ b/internal/app/quiver/quiver.go
@@ -1,0 +1,187 @@
+package quiver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/char2cs/asynx"
+	asynxModels "github.com/char2cs/asynx/models"
+	quivercmds "github.com/rabbytesoftware/quiver/internal/app/quiver/commands"
+	quiverstore "github.com/rabbytesoftware/quiver/internal/app/quiver/store"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	"github.com/rabbytesoftware/quiver/internal/engine/manifold"
+	"github.com/rabbytesoftware/quiver/internal/engine/vault"
+)
+
+// QuiverService manages quiver lifecycle: registration, manifest updates, and removal.
+type QuiverService interface {
+	Add(ctx context.Context, ns domain.Namespace) error
+	Update(ctx context.Context, ns domain.Namespace) error
+	Remove(ctx context.Context, ns domain.Namespace) error
+	List(ctx context.Context) ([]QuiverListDTO, error)
+	GetDetail(ctx context.Context, ns domain.Namespace) (*QuiverDetailDTO, error)
+}
+
+type quiverService struct {
+	asynxQuiver asynx.Asynx[domain.Quiver]
+	catalog     quiverstore.QuiverCatalog
+	vault       vault.Vault
+	manifold    manifold.Manifold
+	os          string
+}
+
+func (svc *quiverService) Add(ctx context.Context, ns domain.Namespace) error {
+	if ns.Validate() != nil {
+		return fmt.Errorf("add quiver: %w", ErrInvalidNamespace)
+	}
+
+	manifest, _, err := svc.resolveManifest(ctx, ns)
+	if err != nil {
+		return fmt.Errorf("add quiver: %w", ErrFetchFailed)
+	}
+
+	if err := svc.asynxQuiver.Send(ctx, quivercmds.AddQuiver{
+		Namespace: ns,
+		Manifest:  *manifest,
+	}); err != nil {
+		return fmt.Errorf("add quiver: %w", err)
+	}
+
+	return nil
+}
+
+func (svc *quiverService) Update(ctx context.Context, ns domain.Namespace) error {
+	current, err := svc.asynxQuiver.Get(ctx, ns.String())
+	if err != nil {
+		if errors.Is(err, asynxModels.ErrNotFound) {
+			return fmt.Errorf("update quiver: %w", ErrNotFound)
+		}
+		return fmt.Errorf("update quiver: %w", err)
+	}
+
+	if current.Removed {
+		return fmt.Errorf("update quiver: %w", ErrAlreadyRemoved)
+	}
+
+	manifest, err := svc.manifold.ResolveQuiver(ctx, ns)
+	if err != nil {
+		return fmt.Errorf("update quiver: %w", ErrFetchFailed)
+	}
+
+	if _, err := svc.vault.PutQuiver(ctx, ns, manifest); err != nil {
+		return fmt.Errorf("update quiver: %w", err)
+	}
+
+	if err := svc.asynxQuiver.Send(ctx, quivercmds.UpdateQuiverManifest{
+		Namespace: ns,
+		Manifest:  *manifest,
+	}); err != nil {
+		return fmt.Errorf("update quiver: %w", err)
+	}
+
+	return nil
+}
+
+func (svc *quiverService) Remove(ctx context.Context, ns domain.Namespace) error {
+	current, err := svc.asynxQuiver.Get(ctx, ns.String())
+	if err != nil {
+		if errors.Is(err, asynxModels.ErrNotFound) {
+			return fmt.Errorf("remove quiver: %w", ErrNotFound)
+		}
+		return fmt.Errorf("remove quiver: %w", err)
+	}
+
+	if current.Removed {
+		return fmt.Errorf("remove quiver: %w", ErrAlreadyRemoved)
+	}
+
+	if err := svc.asynxQuiver.Send(ctx, quivercmds.RemoveQuiver{Namespace: ns}); err != nil {
+		return fmt.Errorf("remove quiver: %w", err)
+	}
+
+	_ = svc.vault.DeleteQuiver(ctx, ns) // best-effort: removal proceeds even if vault cleanup fails
+
+	return nil
+}
+
+func (s *quiverService) List(_ context.Context) ([]QuiverListDTO, error) {
+	quivers, err := s.catalog.List()
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]QuiverListDTO, 0, len(quivers))
+	for _, quiver := range quivers {
+		if quiver.Removed {
+			continue
+		}
+
+		result = append(result, QuiverListDTO{
+			Namespace:   quiver.Namespace,
+			Name:        quiver.Manifest.Name,
+			Description: quiver.Manifest.Description,
+			Tags:        quiver.Manifest.Tags,
+			Removed:     quiver.Removed,
+		})
+	}
+
+	return result, nil
+}
+
+func (s *quiverService) GetDetail(_ context.Context, ns domain.Namespace) (*QuiverDetailDTO, error) {
+	quiver, err := s.catalog.Get(ns)
+	if err != nil {
+		return nil, err
+	}
+	if quiver == nil {
+		return nil, fmt.Errorf("get detail: %w", ErrNotFound)
+	}
+
+	return &QuiverDetailDTO{
+		Namespace: quiver.Namespace,
+		Manifest:  quiver.Manifest,
+		Removed:   quiver.Removed,
+	}, nil
+}
+
+func (s *quiverService) resolveManifest(
+	ctx context.Context,
+	ns domain.Namespace,
+) (*domain.QuiverManifest, string, error) {
+	entry, homePath, err := s.vault.GetQuiver(ctx, ns)
+
+	if err == nil {
+		return entry.Manifest, homePath, nil
+	}
+
+	if errors.Is(err, vault.ErrStale) {
+		manifest, manifoldErr := s.manifold.ResolveQuiver(ctx, ns)
+		if manifoldErr != nil {
+			return entry.Manifest, homePath, nil
+		}
+
+		newPath, putErr := s.vault.PutQuiver(ctx, ns, manifest)
+		if putErr != nil {
+			return nil, "", fmt.Errorf("resolveManifest: store refreshed manifest: %w", putErr)
+		}
+
+		return manifest, newPath, nil
+	}
+
+	if errors.Is(err, vault.ErrNotCached) {
+		manifest, manifoldErr := s.manifold.ResolveQuiver(ctx, ns)
+		if manifoldErr != nil {
+			return nil, "", fmt.Errorf("resolveManifest: fetch from manifold: %w", manifoldErr)
+		}
+
+		newPath, putErr := s.vault.PutQuiver(ctx, ns, manifest)
+		if putErr != nil {
+			return nil, "", fmt.Errorf("resolveManifest: store manifest: %w", putErr)
+		}
+
+		return manifest, newPath, nil
+	}
+
+	return nil, "", fmt.Errorf("resolveManifest: vault lookup: %w", err)
+}

--- a/internal/app/quiver/quiver_test.go
+++ b/internal/app/quiver/quiver_test.go
@@ -1,0 +1,431 @@
+package quiver
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	quivercmds "github.com/rabbytesoftware/quiver/internal/app/quiver/commands"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	"github.com/rabbytesoftware/quiver/internal/engine/vault"
+	"github.com/rabbytesoftware/quiver/internal/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Add ---
+
+func TestAdd_InvalidNamespace_ReturnsErrInvalidNamespace(t *testing.T) {
+	svc := testQuiverService(t, &mocks.Vault{}, &mocks.Manifold{})
+
+	err := svc.Add(context.Background(), "bad-namespace")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidNamespace)
+}
+
+func TestAdd_ManifoldFails_ReturnsErrFetchFailed(t *testing.T) {
+	mv := &mocks.Vault{GetQuiverErr: vault.ErrNotCached}
+	mm := &mocks.Manifold{ResolveQuiverErr: errors.New("network error")}
+	svc := testQuiverService(t, mv, mm)
+
+	err := svc.Add(context.Background(), "github.com/org/repo")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrFetchFailed)
+}
+
+func TestAdd_Success_QuiverSentToAsynx(t *testing.T) {
+	manifest := makeTestManifest("MyQuiver")
+	mv := &mocks.Vault{
+		GetQuiverErr:  vault.ErrNotCached,
+		PutQuiverPath: "/tmp/test",
+	}
+	mm := &mocks.Manifold{ResolveQuiverManifest: manifest}
+	svc := testQuiverService(t, mv, mm)
+
+	err := svc.Add(context.Background(), "github.com/org/repo")
+	require.NoError(t, err)
+
+	svc.asynxQuiver.WaitPublish()
+
+	got, err := svc.asynxQuiver.Get(context.Background(), "github.com/org/repo")
+	require.NoError(t, err)
+	assert.Equal(t, domain.Namespace("github.com/org/repo"), got.Namespace)
+	assert.False(t, got.Removed)
+}
+
+func TestAdd_AlreadyExists_ReturnsError(t *testing.T) {
+	manifest := makeTestManifest("MyQuiver")
+	mv := &mocks.Vault{
+		GetQuiverErr:  vault.ErrNotCached,
+		PutQuiverPath: "/tmp/test",
+	}
+	mm := &mocks.Manifold{ResolveQuiverManifest: manifest}
+	svc := testQuiverService(t, mv, mm)
+
+	require.NoError(t, svc.Add(context.Background(), "github.com/org/repo"))
+	svc.asynxQuiver.WaitPublish()
+
+	err := svc.Add(context.Background(), "github.com/org/repo")
+	require.Error(t, err)
+}
+
+// --- Update ---
+
+func TestUpdate_NotFound_ReturnsErrNotFound(t *testing.T) {
+	mv := &mocks.Vault{GetQuiverErr: vault.ErrNotCached}
+	mm := &mocks.Manifold{}
+	svc := testQuiverService(t, mv, mm)
+
+	err := svc.Update(context.Background(), "github.com/org/repo")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestUpdate_AlreadyRemoved_ReturnsErrAlreadyRemoved(t *testing.T) {
+	manifest := makeTestManifest("MyQuiver")
+	mv := &mocks.Vault{
+		GetQuiverErr:  vault.ErrNotCached,
+		PutQuiverPath: "/tmp/test",
+	}
+	mm := &mocks.Manifold{ResolveQuiverManifest: manifest}
+	svc := testQuiverService(t, mv, mm)
+
+	addQuiverForTest(t, svc, "github.com/org/repo", manifest)
+
+	// Mark as removed via command
+	require.NoError(t, svc.asynxQuiver.Send(context.Background(), quivercmds.RemoveQuiver{Namespace: "github.com/org/repo"}))
+	svc.asynxQuiver.WaitPublish()
+
+	err := svc.Update(context.Background(), "github.com/org/repo")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrAlreadyRemoved)
+}
+
+func TestUpdate_ManifoldFails_ReturnsErrFetchFailed(t *testing.T) {
+	manifest := makeTestManifest("MyQuiver")
+	mv := &mocks.Vault{
+		GetQuiverErr:  vault.ErrNotCached,
+		PutQuiverPath: "/tmp/test",
+	}
+	mm := &mocks.Manifold{ResolveQuiverManifest: manifest}
+	svc := testQuiverService(t, mv, mm)
+
+	addQuiverForTest(t, svc, "github.com/org/repo", manifest)
+
+	// Now make manifold fail
+	mm.ResolveQuiverErr = errors.New("network error")
+	mm.ResolveQuiverManifest = nil
+
+	err := svc.Update(context.Background(), "github.com/org/repo")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrFetchFailed)
+}
+
+func TestUpdate_Success_UpdatesQuiver(t *testing.T) {
+	manifest := makeTestManifest("MyQuiver")
+	updatedManifest := makeTestManifest("UpdatedQuiver")
+	mv := &mocks.Vault{
+		GetQuiverErr:  vault.ErrNotCached,
+		PutQuiverPath: "/tmp/test",
+	}
+	mm := &mocks.Manifold{ResolveQuiverManifest: manifest}
+	svc := testQuiverService(t, mv, mm)
+
+	addQuiverForTest(t, svc, "github.com/org/repo", manifest)
+
+	mm.ResolveQuiverManifest = updatedManifest
+	err := svc.Update(context.Background(), "github.com/org/repo")
+	require.NoError(t, err)
+	svc.asynxQuiver.WaitPublish()
+
+	got, err := svc.asynxQuiver.Get(context.Background(), "github.com/org/repo")
+	require.NoError(t, err)
+	assert.Equal(t, "UpdatedQuiver", got.Manifest.Name)
+}
+
+// --- Remove ---
+
+func TestRemove_NotFound_ReturnsErrNotFound(t *testing.T) {
+	mv := &mocks.Vault{GetQuiverErr: vault.ErrNotCached}
+	mm := &mocks.Manifold{}
+	svc := testQuiverService(t, mv, mm)
+
+	err := svc.Remove(context.Background(), "github.com/org/repo")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestRemove_AlreadyRemoved_ReturnsErrAlreadyRemoved(t *testing.T) {
+	manifest := makeTestManifest("MyQuiver")
+	mv := &mocks.Vault{
+		GetQuiverErr:  vault.ErrNotCached,
+		PutQuiverPath: "/tmp/test",
+	}
+	mm := &mocks.Manifold{ResolveQuiverManifest: manifest}
+	svc := testQuiverService(t, mv, mm)
+
+	addQuiverForTest(t, svc, "github.com/org/repo", manifest)
+
+	// Remove once
+	require.NoError(t, svc.Remove(context.Background(), "github.com/org/repo"))
+	svc.asynxQuiver.WaitPublish()
+
+	// Remove again — should fail
+	err := svc.Remove(context.Background(), "github.com/org/repo")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrAlreadyRemoved)
+}
+
+func TestRemove_Success_QuiverMarkedRemoved(t *testing.T) {
+	manifest := makeTestManifest("MyQuiver")
+	mv := &mocks.Vault{
+		GetQuiverErr:  vault.ErrNotCached,
+		PutQuiverPath: "/tmp/test",
+	}
+	mm := &mocks.Manifold{ResolveQuiverManifest: manifest}
+	svc := testQuiverService(t, mv, mm)
+
+	addQuiverForTest(t, svc, "github.com/org/repo", manifest)
+
+	err := svc.Remove(context.Background(), "github.com/org/repo")
+	require.NoError(t, err)
+	svc.asynxQuiver.WaitPublish()
+
+	got, err := svc.asynxQuiver.Get(context.Background(), "github.com/org/repo")
+	require.NoError(t, err)
+	assert.True(t, got.Removed)
+}
+
+// --- List ---
+
+func TestList_EmptyCatalog_ReturnsEmpty(t *testing.T) {
+	svc := testQuiverService(t, &mocks.Vault{}, &mocks.Manifold{})
+
+	result, err := svc.List(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestList_FiltersRemovedQuivers(t *testing.T) {
+	manifest := makeTestManifest("Quiver")
+	svc := testQuiverService(t, &mocks.Vault{}, &mocks.Manifold{})
+
+	require.NoError(t, svc.catalog.Save(domain.Quiver{
+		Namespace: "github.com/org/active",
+		Manifest:  *manifest,
+		Removed:   false,
+	}))
+	require.NoError(t, svc.catalog.Save(domain.Quiver{
+		Namespace: "github.com/org/removed",
+		Manifest:  *manifest,
+		Removed:   true,
+	}))
+
+	result, err := svc.List(context.Background())
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, domain.Namespace("github.com/org/active"), result[0].Namespace)
+}
+
+func TestList_IncludesManifestFields(t *testing.T) {
+	svc := testQuiverService(t, &mocks.Vault{}, &mocks.Manifold{})
+
+	require.NoError(t, svc.catalog.Save(domain.Quiver{
+		Namespace: "github.com/org/repo",
+		Manifest: domain.QuiverManifest{
+			Name:        "TestQuiver",
+			Description: "A test",
+			Tags:        []string{"tag1", "tag2"},
+		},
+		Removed: false,
+	}))
+
+	result, err := svc.List(context.Background())
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, "TestQuiver", result[0].Name)
+	assert.Equal(t, "A test", result[0].Description)
+	assert.Equal(t, []string{"tag1", "tag2"}, result[0].Tags)
+}
+
+// --- GetDetail ---
+
+func TestGetDetail_NotFound_ReturnsErrNotFound(t *testing.T) {
+	svc := testQuiverService(t, &mocks.Vault{}, &mocks.Manifold{})
+
+	detail, err := svc.GetDetail(context.Background(), "github.com/org/repo")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotFound)
+	assert.Nil(t, detail)
+}
+
+func TestGetDetail_Found_ReturnsDetailDTO(t *testing.T) {
+	svc := testQuiverService(t, &mocks.Vault{}, &mocks.Manifold{})
+
+	ns := domain.Namespace("github.com/org/repo")
+	require.NoError(t, svc.catalog.Save(domain.Quiver{
+		Namespace: ns,
+		Manifest: domain.QuiverManifest{
+			Name:        "TestQuiver",
+			Description: "Desc",
+			Tags:        []string{"a", "b"},
+		},
+		Removed: false,
+	}))
+
+	detail, err := svc.GetDetail(context.Background(), ns)
+	require.NoError(t, err)
+	require.NotNil(t, detail)
+	assert.Equal(t, ns, detail.Namespace)
+	assert.Equal(t, "TestQuiver", detail.Manifest.Name)
+	assert.Equal(t, "Desc", detail.Manifest.Description)
+	assert.False(t, detail.Removed)
+}
+
+func TestGetDetail_RemovedQuiver_ReturnsRemovedTrue(t *testing.T) {
+	svc := testQuiverService(t, &mocks.Vault{}, &mocks.Manifold{})
+
+	ns := domain.Namespace("github.com/org/repo")
+	require.NoError(t, svc.catalog.Save(domain.Quiver{
+		Namespace: ns,
+		Manifest:  domain.QuiverManifest{Name: "TestQuiver"},
+		Removed:   true,
+	}))
+
+	detail, err := svc.GetDetail(context.Background(), ns)
+	require.NoError(t, err)
+	require.NotNil(t, detail)
+	assert.True(t, detail.Removed)
+}
+
+// --- resolveManifest ---
+
+func TestResolveManifest_FreshVaultHit_ReturnsManifestDirectly(t *testing.T) {
+	manifest := makeTestManifest("FreshQuiver")
+	mv := &mocks.Vault{
+		GetQuiverEntry: &vault.QuiverVaultEntry{Manifest: manifest},
+		GetQuiverPath:  "/home/fresh",
+		GetQuiverErr:   nil,
+	}
+	mm := &mocks.Manifold{}
+	svc := makeQuiverServiceWithMocks(mv, mm)
+
+	got, path, err := svc.resolveManifest(context.Background(), "github.com/org/repo")
+	require.NoError(t, err)
+	assert.Equal(t, manifest, got)
+	assert.Equal(t, "/home/fresh", path)
+	assert.Equal(t, 0, mv.PutQuiverCalls)
+}
+
+func TestResolveManifest_StaleVaultManifoldSucceeds_ReturnsFreshManifest(t *testing.T) {
+	staleManifest := makeTestManifest("StaleQuiver")
+	freshManifest := makeTestManifest("FreshQuiver")
+	mv := &mocks.Vault{
+		GetQuiverEntry: &vault.QuiverVaultEntry{Manifest: staleManifest},
+		GetQuiverPath:  "/home/stale",
+		GetQuiverErr:   vault.ErrStale,
+		PutQuiverPath:  "/home/fresh",
+	}
+	mm := &mocks.Manifold{ResolveQuiverManifest: freshManifest}
+	svc := makeQuiverServiceWithMocks(mv, mm)
+
+	got, path, err := svc.resolveManifest(context.Background(), "github.com/org/repo")
+	require.NoError(t, err)
+	assert.Equal(t, freshManifest, got)
+	assert.Equal(t, "/home/fresh", path)
+	assert.Equal(t, 1, mv.PutQuiverCalls)
+}
+
+func TestResolveManifest_StaleVaultManifoldFails_ReturnsStaleManifest(t *testing.T) {
+	staleManifest := makeTestManifest("StaleQuiver")
+	mv := &mocks.Vault{
+		GetQuiverEntry: &vault.QuiverVaultEntry{Manifest: staleManifest},
+		GetQuiverPath:  "/home/stale",
+		GetQuiverErr:   vault.ErrStale,
+	}
+	mm := &mocks.Manifold{ResolveQuiverErr: errors.New("network error")}
+	svc := makeQuiverServiceWithMocks(mv, mm)
+
+	got, path, err := svc.resolveManifest(context.Background(), "github.com/org/repo")
+	require.NoError(t, err)
+	assert.Equal(t, staleManifest, got)
+	assert.Equal(t, "/home/stale", path)
+	assert.Equal(t, 0, mv.PutQuiverCalls)
+}
+
+func TestResolveManifest_NotCachedManifoldSucceeds_ReturnsManifestAndStores(t *testing.T) {
+	freshManifest := makeTestManifest("NewQuiver")
+	mv := &mocks.Vault{
+		GetQuiverErr:  vault.ErrNotCached,
+		PutQuiverPath: "/home/new",
+	}
+	mm := &mocks.Manifold{ResolveQuiverManifest: freshManifest}
+	svc := makeQuiverServiceWithMocks(mv, mm)
+
+	got, path, err := svc.resolveManifest(context.Background(), "github.com/org/repo")
+	require.NoError(t, err)
+	assert.Equal(t, freshManifest, got)
+	assert.Equal(t, "/home/new", path)
+	assert.Equal(t, 1, mv.PutQuiverCalls)
+}
+
+func TestResolveManifest_NotCachedManifoldFails_ReturnsError(t *testing.T) {
+	mv := &mocks.Vault{
+		GetQuiverErr: vault.ErrNotCached,
+	}
+	mm := &mocks.Manifold{ResolveQuiverErr: errors.New("network error")}
+	svc := makeQuiverServiceWithMocks(mv, mm)
+
+	got, path, err := svc.resolveManifest(context.Background(), "github.com/org/repo")
+	assert.Error(t, err)
+	assert.Nil(t, got)
+	assert.Empty(t, path)
+}
+
+func TestResolveManifest_StaleVaultPutFails_ReturnsError(t *testing.T) {
+	staleManifest := makeTestManifest("StaleQuiver")
+	freshManifest := makeTestManifest("FreshQuiver")
+	mv := &mocks.Vault{
+		GetQuiverEntry: &vault.QuiverVaultEntry{Manifest: staleManifest},
+		GetQuiverPath:  "/home/stale",
+		GetQuiverErr:   vault.ErrStale,
+		PutQuiverErr:   errors.New("disk full"),
+	}
+	mm := &mocks.Manifold{ResolveQuiverManifest: freshManifest}
+	svc := makeQuiverServiceWithMocks(mv, mm)
+
+	got, path, err := svc.resolveManifest(context.Background(), "github.com/org/repo")
+	assert.Error(t, err)
+	assert.Nil(t, got)
+	assert.Empty(t, path)
+}
+
+func TestResolveManifest_NotCachedPutFails_ReturnsError(t *testing.T) {
+	freshManifest := makeTestManifest("NewQuiver")
+	mv := &mocks.Vault{
+		GetQuiverErr: vault.ErrNotCached,
+		PutQuiverErr: errors.New("disk full"),
+	}
+	mm := &mocks.Manifold{ResolveQuiverManifest: freshManifest}
+	svc := makeQuiverServiceWithMocks(mv, mm)
+
+	got, path, err := svc.resolveManifest(context.Background(), "github.com/org/repo")
+	assert.Error(t, err)
+	assert.Nil(t, got)
+	assert.Empty(t, path)
+}
+
+func TestResolveManifest_UnexpectedVaultError_ReturnsError(t *testing.T) {
+	unexpectedErr := errors.New("disk failure")
+	mv := &mocks.Vault{
+		GetQuiverErr: unexpectedErr,
+	}
+	mm := &mocks.Manifold{}
+	svc := makeQuiverServiceWithMocks(mv, mm)
+
+	got, path, err := svc.resolveManifest(context.Background(), "github.com/org/repo")
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, unexpectedErr)
+	assert.Nil(t, got)
+	assert.Empty(t, path)
+}

--- a/internal/app/quiver/service.go
+++ b/internal/app/quiver/service.go
@@ -1,1 +1,0 @@
-package quiver

--- a/internal/app/quiver/store/store.go
+++ b/internal/app/quiver/store/store.go
@@ -1,0 +1,147 @@
+package store
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/rabbytesoftware/quiver/internal/core/metadata"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	_ "modernc.org/sqlite"
+)
+
+type QuiverCatalog interface {
+	Save(quiver domain.Quiver) error
+	Delete(ns domain.Namespace) error
+	Get(ns domain.Namespace) (*domain.Quiver, error)
+	List() ([]domain.Quiver, error)
+}
+
+type quiverRow struct {
+	Namespace string `db:"namespace"`
+	Manifest  string `db:"manifest"`
+	Removed   bool   `db:"removed"`
+}
+
+type quiverCatalog struct {
+	db *sqlx.DB
+	mu sync.RWMutex
+}
+
+func NewQuiverCatalog() (QuiverCatalog, error) {
+	return NewQuiverCatalogFromPath(metadata.GetQuiverHome() + "/quivers.db")
+}
+
+func NewQuiverCatalogFromPath(path string) (QuiverCatalog, error) {
+	db, err := sqlx.Open("sqlite", path)
+	if err != nil {
+		return nil, fmt.Errorf("quiver catalog: open: %w", err)
+	}
+
+	_, err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS quivers (
+			namespace TEXT PRIMARY KEY,
+			manifest TEXT NOT NULL,
+			removed INTEGER NOT NULL DEFAULT 0
+		)
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("quiver catalog: schema: %w", err)
+	}
+
+	return &quiverCatalog{db: db}, nil
+}
+
+func (qc *quiverCatalog) Save(quiver domain.Quiver) error {
+	qc.mu.Lock()
+	defer qc.mu.Unlock()
+
+	manifestJSON, err := json.Marshal(quiver.Manifest)
+	if err != nil {
+		return err
+	}
+
+	row := quiverRow{
+		Namespace: quiver.Namespace.String(),
+		Manifest:  string(manifestJSON),
+		Removed:   quiver.Removed,
+	}
+
+	_, err = qc.db.NamedExec(
+		`INSERT OR REPLACE INTO quivers (namespace, manifest, removed) VALUES (:namespace, :manifest, :removed)`,
+		row,
+	)
+	if err != nil {
+		return fmt.Errorf("quiver catalog: save: %w", err)
+	}
+
+	return nil
+}
+
+func (qc *quiverCatalog) Delete(ns domain.Namespace) error {
+	qc.mu.Lock()
+	defer qc.mu.Unlock()
+
+	_, err := qc.db.Exec(`DELETE FROM quivers WHERE namespace = ?`, ns.String())
+	if err != nil {
+		return fmt.Errorf("quiver catalog: delete: %w", err)
+	}
+
+	return nil
+}
+
+func (qc *quiverCatalog) Get(ns domain.Namespace) (*domain.Quiver, error) {
+	qc.mu.RLock()
+	defer qc.mu.RUnlock()
+
+	var row quiverRow
+	err := qc.db.Get(&row, `SELECT namespace, manifest, removed FROM quivers WHERE namespace = ?`, ns.String())
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var manifest domain.QuiverManifest
+	err = json.Unmarshal([]byte(row.Manifest), &manifest)
+	if err != nil {
+		return nil, err
+	}
+
+	return &domain.Quiver{
+		Namespace: domain.Namespace(row.Namespace),
+		Manifest:  manifest,
+		Removed:   row.Removed,
+	}, nil
+}
+
+func (qc *quiverCatalog) List() ([]domain.Quiver, error) {
+	qc.mu.RLock()
+	defer qc.mu.RUnlock()
+
+	var rows []quiverRow
+	err := qc.db.Select(&rows, `SELECT namespace, manifest, removed FROM quivers`)
+	if err != nil {
+		return nil, err
+	}
+
+	quivers := make([]domain.Quiver, 0, len(rows))
+	for _, row := range rows {
+		var manifest domain.QuiverManifest
+		err := json.Unmarshal([]byte(row.Manifest), &manifest)
+		if err != nil {
+			return nil, err
+		}
+
+		quivers = append(quivers, domain.Quiver{
+			Namespace: domain.Namespace(row.Namespace),
+			Manifest:  manifest,
+			Removed:   row.Removed,
+		})
+	}
+
+	return quivers, nil
+}

--- a/internal/app/quiver/store/store_test.go
+++ b/internal/app/quiver/store/store_test.go
@@ -1,0 +1,117 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeTestQuiver(ns string, name string) domain.Quiver {
+	return domain.Quiver{
+		Namespace: domain.Namespace(ns),
+		Manifest: domain.QuiverManifest{
+			Name:        name,
+			Description: "A test quiver",
+			Tags:        []string{"test"},
+		},
+		Removed: false,
+	}
+}
+
+func TestQuiverCatalog_SaveAndGet_ReturnsSavedQuiver(t *testing.T) {
+	c, err := NewQuiverCatalogFromPath(":memory:")
+	require.NoError(t, err)
+
+	quiver := makeTestQuiver("github.com/org/repo", "MyQuiver")
+
+	err = c.Save(quiver)
+	require.NoError(t, err)
+
+	got, err := c.Get(quiver.Namespace)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, quiver.Namespace, got.Namespace)
+	assert.Equal(t, quiver.Manifest.Name, got.Manifest.Name)
+	assert.Equal(t, quiver.Manifest.Description, got.Manifest.Description)
+	assert.Equal(t, quiver.Removed, got.Removed)
+}
+
+func TestQuiverCatalog_SaveDeleteGet_ReturnsNil(t *testing.T) {
+	c, err := NewQuiverCatalogFromPath(":memory:")
+	require.NoError(t, err)
+
+	quiver := makeTestQuiver("github.com/org/repo", "MyQuiver")
+
+	err = c.Save(quiver)
+	require.NoError(t, err)
+
+	err = c.Delete(quiver.Namespace)
+	require.NoError(t, err)
+
+	got, err := c.Get(quiver.Namespace)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestQuiverCatalog_List_ReturnsAllSaved(t *testing.T) {
+	c, err := NewQuiverCatalogFromPath(":memory:")
+	require.NoError(t, err)
+
+	q1 := makeTestQuiver("github.com/org/repo1", "Quiver1")
+	q2 := makeTestQuiver("github.com/org/repo2", "Quiver2")
+
+	require.NoError(t, c.Save(q1))
+	require.NoError(t, c.Save(q2))
+
+	quivers, err := c.List()
+	require.NoError(t, err)
+	assert.Len(t, quivers, 2)
+
+	namespaces := make([]domain.Namespace, 0, len(quivers))
+	for _, q := range quivers {
+		namespaces = append(namespaces, q.Namespace)
+	}
+	assert.Contains(t, namespaces, q1.Namespace)
+	assert.Contains(t, namespaces, q2.Namespace)
+}
+
+func TestQuiverCatalog_ListAfterRemove_ReturnsEmpty(t *testing.T) {
+	c, err := NewQuiverCatalogFromPath(":memory:")
+	require.NoError(t, err)
+
+	quiver := makeTestQuiver("github.com/org/repo", "MyQuiver")
+
+	require.NoError(t, c.Save(quiver))
+	require.NoError(t, c.Delete(quiver.Namespace))
+
+	quivers, err := c.List()
+	require.NoError(t, err)
+	assert.Empty(t, quivers)
+}
+
+func TestQuiverCatalog_GetNonExistent_ReturnsNil(t *testing.T) {
+	c, err := NewQuiverCatalogFromPath(":memory:")
+	require.NoError(t, err)
+
+	got, err := c.Get("github.com/org/nonexistent")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestQuiverCatalog_Save_UpdatesExisting(t *testing.T) {
+	c, err := NewQuiverCatalogFromPath(":memory:")
+	require.NoError(t, err)
+
+	quiver := makeTestQuiver("github.com/org/repo", "MyQuiver")
+	require.NoError(t, c.Save(quiver))
+
+	quiver.Manifest.Name = "UpdatedQuiver"
+	require.NoError(t, c.Save(quiver))
+
+	got, err := c.Get(quiver.Namespace)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "UpdatedQuiver", got.Manifest.Name)
+}

--- a/internal/app/quiver/test_helpers_test.go
+++ b/internal/app/quiver/test_helpers_test.go
@@ -1,0 +1,57 @@
+package quiver
+
+import (
+	"context"
+	"testing"
+
+	sqlite "github.com/rabbytesoftware/quiver/internal/adapter/eventstore/sqlite"
+	quivercmds "github.com/rabbytesoftware/quiver/internal/app/quiver/commands"
+	quiverstore "github.com/rabbytesoftware/quiver/internal/app/quiver/store"
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	"github.com/rabbytesoftware/quiver/internal/mocks"
+	"github.com/stretchr/testify/require"
+)
+
+func makeTestManifest(name string) *domain.QuiverManifest {
+	return &domain.QuiverManifest{
+		Name:        name,
+		Description: "A test quiver",
+		Tags:        []string{"test"},
+	}
+}
+
+func makeQuiverServiceWithMocks(v *mocks.Vault, m *mocks.Manifold) *quiverService {
+	return &quiverService{
+		vault:    v,
+		manifold: m,
+	}
+}
+
+func testQuiverService(t *testing.T, v *mocks.Vault, m *mocks.Manifold) *quiverService {
+	t.Helper()
+
+	es, err := sqlite.NewEventStore(":memory:")
+	require.NoError(t, err)
+
+	axQuiver, err := newAsynxQuiver(es)
+	require.NoError(t, err)
+
+	catalog, err := quiverstore.NewQuiverCatalogFromPath(":memory:")
+	require.NoError(t, err)
+
+	return &quiverService{
+		asynxQuiver: axQuiver,
+		catalog:     catalog,
+		vault:       v,
+		manifold:    m,
+	}
+}
+
+func addQuiverForTest(t *testing.T, svc *quiverService, ns domain.Namespace, manifest *domain.QuiverManifest) {
+	t.Helper()
+	require.NoError(t, svc.asynxQuiver.Send(context.Background(), quivercmds.AddQuiver{
+		Namespace: ns,
+		Manifest:  *manifest,
+	}))
+	svc.asynxQuiver.WaitPublish()
+}

--- a/internal/app/quiver/types.go
+++ b/internal/app/quiver/types.go
@@ -1,0 +1,30 @@
+package quiver
+
+import (
+	"errors"
+
+	"github.com/rabbytesoftware/quiver/internal/domain"
+)
+
+var (
+	ErrNotFound         = errors.New("not found")
+	ErrAlreadyExists    = errors.New("already exists")
+	ErrAlreadyRemoved   = errors.New("already removed")
+	ErrStateViolation   = errors.New("state violation")
+	ErrFetchFailed      = errors.New("fetch failed")
+	ErrInvalidNamespace = errors.New("invalid namespace")
+)
+
+type QuiverListDTO struct {
+	Namespace   domain.Namespace `json:"namespace"`
+	Name        string           `json:"name"`
+	Description string           `json:"description"`
+	Tags        []string         `json:"tags"`
+	Removed     bool             `json:"removed"`
+}
+
+type QuiverDetailDTO struct {
+	Namespace domain.Namespace      `json:"namespace"`
+	Manifest  domain.QuiverManifest `json:"manifest"`
+	Removed   bool                  `json:"removed"`
+}

--- a/internal/domain/runtime/step_progress.go
+++ b/internal/domain/runtime/step_progress.go
@@ -1,6 +1,11 @@
 package runtime
 
-import "github.com/rabbytesoftware/quiver/internal/domain/runtime/step"
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/rabbytesoftware/quiver/internal/domain/runtime/step"
+)
 
 type StepStatus string
 
@@ -16,4 +21,38 @@ type StepProgress struct {
 	Status StepStatus
 	Error  *string
 	Step   step.Step
+}
+
+type stepProgressJSON struct {
+	Index  int           `json:"Index"`
+	Status StepStatus    `json:"Status"`
+	Error  *string       `json:"Error"`
+	Step   step.StepList `json:"Step"`
+}
+
+func (sp StepProgress) MarshalJSON() ([]byte, error) {
+	var steps step.StepList
+	if sp.Step != nil {
+		steps = step.StepList{sp.Step}
+	}
+	return json.Marshal(stepProgressJSON{
+		Index:  sp.Index,
+		Status: sp.Status,
+		Error:  sp.Error,
+		Step:   steps,
+	})
+}
+
+func (sp *StepProgress) UnmarshalJSON(data []byte) error {
+	var raw stepProgressJSON
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("StepProgress: %w", err)
+	}
+	sp.Index = raw.Index
+	sp.Status = raw.Status
+	sp.Error = raw.Error
+	if len(raw.Step) > 0 {
+		sp.Step = raw.Step[0]
+	}
+	return nil
 }

--- a/internal/mocks/deptree.go
+++ b/internal/mocks/deptree.go
@@ -1,0 +1,15 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	"github.com/rabbytesoftware/quiver/internal/engine/deptree"
+)
+
+// DepTree returns a DepTree func that always returns the provided result.
+func DepTree(result []domain.Namespace, err error) deptree.DepTree {
+	return func(_ context.Context, _ domain.Namespace, _ deptree.ResolverFunc) ([]domain.Namespace, error) {
+		return result, err
+	}
+}

--- a/internal/mocks/manifold.go
+++ b/internal/mocks/manifold.go
@@ -1,0 +1,26 @@
+package mocks
+
+import (
+	"context"
+	"errors"
+
+	"github.com/rabbytesoftware/quiver/internal/domain"
+)
+
+type Manifold struct {
+	ResolveArrowManifest  *domain.ArrowManifest
+	ResolveArrowErr       error
+	ResolveQuiverManifest *domain.QuiverManifest
+	ResolveQuiverErr      error
+}
+
+func (m *Manifold) ResolveArrow(_ context.Context, _ domain.Namespace) (*domain.ArrowManifest, error) {
+	return m.ResolveArrowManifest, m.ResolveArrowErr
+}
+
+func (m *Manifold) ResolveQuiver(_ context.Context, _ domain.Namespace) (*domain.QuiverManifest, error) {
+	if m.ResolveQuiverManifest != nil || m.ResolveQuiverErr != nil {
+		return m.ResolveQuiverManifest, m.ResolveQuiverErr
+	}
+	return nil, errors.New("not implemented")
+}

--- a/internal/mocks/netbridge.go
+++ b/internal/mocks/netbridge.go
@@ -1,0 +1,21 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/rabbytesoftware/quiver/internal/domain/netbridge"
+)
+
+type Netbridge struct {
+	AllocatePort  int
+	AllocateErr   error
+	DeallocateErr error
+}
+
+func (m *Netbridge) Allocate(_ context.Context, _ string, _ netbridge.Protocol, _ int) (int, error) {
+	return m.AllocatePort, m.AllocateErr
+}
+
+func (m *Netbridge) DeallocateByOwner(_ context.Context, _ string) error {
+	return m.DeallocateErr
+}

--- a/internal/mocks/runtime_cmd.go
+++ b/internal/mocks/runtime_cmd.go
@@ -1,0 +1,41 @@
+package mocks
+
+import (
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	domainRuntime "github.com/rabbytesoftware/quiver/internal/domain/runtime"
+)
+
+// RuntimeCmd seeds an ArrowRuntime aggregate to a given state in tests.
+type RuntimeCmd struct {
+	NS    domain.Namespace
+	State domain.ArrowState
+}
+
+func (c RuntimeCmd) AggregateID() string                          { return c.NS.String() }
+func (c RuntimeCmd) EventName() string                            { return "runtime.mock" }
+func (c RuntimeCmd) ShouldSnapshot() bool                         { return false }
+func (c RuntimeCmd) Validate(_ *domainRuntime.ArrowRuntime) error { return nil }
+func (c RuntimeCmd) EmitEvent(_ *domainRuntime.ArrowRuntime) domainRuntime.ArrowRuntime {
+	return domainRuntime.ArrowRuntime{Namespace: c.NS, State: c.State}
+}
+
+// RuntimeCmdWithExecution seeds an ArrowRuntime with ActiveRun and LastReturn.
+type RuntimeCmdWithExecution struct {
+	NS         domain.Namespace
+	State      domain.ArrowState
+	ActiveRun  *domainRuntime.RunRecord
+	LastReturn *domainRuntime.Return
+}
+
+func (c RuntimeCmdWithExecution) AggregateID() string                          { return c.NS.String() }
+func (c RuntimeCmdWithExecution) EventName() string                            { return "runtime.mock.execution" }
+func (c RuntimeCmdWithExecution) ShouldSnapshot() bool                         { return false }
+func (c RuntimeCmdWithExecution) Validate(_ *domainRuntime.ArrowRuntime) error { return nil }
+func (c RuntimeCmdWithExecution) EmitEvent(_ *domainRuntime.ArrowRuntime) domainRuntime.ArrowRuntime {
+	return domainRuntime.ArrowRuntime{
+		Namespace:  c.NS,
+		State:      c.State,
+		ActiveRun:  c.ActiveRun,
+		LastReturn: c.LastReturn,
+	}
+}

--- a/internal/mocks/vault.go
+++ b/internal/mocks/vault.go
@@ -1,0 +1,52 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	"github.com/rabbytesoftware/quiver/internal/engine/vault"
+)
+
+type Vault struct {
+	GetArrowEntry  *vault.VaultEntry
+	GetArrowPath   string
+	GetArrowErr    error
+	PutArrowPath   string
+	PutArrowErr    error
+	PutArrowCalls  int
+	DeleteArrowErr error
+
+	GetQuiverEntry  *vault.QuiverVaultEntry
+	GetQuiverPath   string
+	GetQuiverErr    error
+	PutQuiverPath   string
+	PutQuiverErr    error
+	PutQuiverCalls  int
+	DeleteQuiverErr error
+}
+
+func (m *Vault) GetArrow(_ context.Context, _ domain.Namespace) (*vault.VaultEntry, string, error) {
+	return m.GetArrowEntry, m.GetArrowPath, m.GetArrowErr
+}
+
+func (m *Vault) PutArrow(_ context.Context, _ domain.Namespace, _ *domain.ArrowManifest, _ []domain.Namespace) (string, error) {
+	m.PutArrowCalls++
+	return m.PutArrowPath, m.PutArrowErr
+}
+
+func (m *Vault) DeleteArrow(_ context.Context, _ domain.Namespace) error {
+	return m.DeleteArrowErr
+}
+
+func (m *Vault) GetQuiver(_ context.Context, _ domain.Namespace) (*vault.QuiverVaultEntry, string, error) {
+	return m.GetQuiverEntry, m.GetQuiverPath, m.GetQuiverErr
+}
+
+func (m *Vault) PutQuiver(_ context.Context, _ domain.Namespace, _ *domain.QuiverManifest) (string, error) {
+	m.PutQuiverCalls++
+	return m.PutQuiverPath, m.PutQuiverErr
+}
+
+func (m *Vault) DeleteQuiver(_ context.Context, _ domain.Namespace) error {
+	return m.DeleteQuiverErr
+}

--- a/internal/mocks/wizard.go
+++ b/internal/mocks/wizard.go
@@ -1,0 +1,39 @@
+package mocks
+
+import (
+	"context"
+	"sync"
+
+	"github.com/rabbytesoftware/quiver/internal/domain"
+	"github.com/rabbytesoftware/quiver/internal/engine/wizard"
+)
+
+type Wizard struct {
+	mu            sync.Mutex
+	ExecuteErr    error
+	ExecuteCalled bool
+	CancelledNS   domain.Namespace
+}
+
+func (m *Wizard) Execute(_ context.Context, _ wizard.RunRequest, _ wizard.StepReporter) error {
+	m.mu.Lock()
+	m.ExecuteCalled = true
+	m.mu.Unlock()
+	return m.ExecuteErr
+}
+
+func (m *Wizard) Cancel(ns domain.Namespace) {
+	m.mu.Lock()
+	m.CancelledNS = ns
+	m.mu.Unlock()
+}
+
+func (m *Wizard) Shutdown(_ context.Context) error {
+	return nil
+}
+
+func (m *Wizard) WasExecuteCalled() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.ExecuteCalled
+}


### PR DESCRIPTION
## Summary

- Implements full Arrow service layer: Add/Update/Remove/List/GetDetail + Install/Uninstall/BeginExecution/Stop with 6-layer variable resolution, dependency-tree installs, and stop-on-cancel lifecycle handling
- Implements full Quiver service layer: Add/Update/Remove/List/GetDetail with manifest caching via vault
- Both services use Asynx CQRS (two aggregates: manifest + runtime state), SQLite read models (`store/`), builder pattern, and centralized `internal/mocks/` for all engine interfaces

## Test Plan
- [ ] `go build ./internal/app/...` compiles cleanly
- [ ] `go test ./internal/app/...` all pass
- [ ] `make pr-checks` fully green
- [ ] Arrow integration: install → execute → stop flow
- [ ] Quiver integration: add → resolve manifest flow