### PR TITLE
fix(commands): enable snapshotting for 8 commands per spec

### DIFF
--- a/internal/app/arrow/internal/commands/add.go
+++ b/internal/app/arrow/internal/commands/add.go
@@ -21,7 +21,7 @@ func (c AddArrow) EventName() string {
 }
 
 func (c AddArrow) ShouldSnapshot() bool {
-	return false
+	return true
 }
 
 func (c AddArrow) Validate(current *domain.Arrow) error {

--- a/internal/app/arrow/internal/commands/add_test.go
+++ b/internal/app/arrow/internal/commands/add_test.go
@@ -47,7 +47,7 @@ func TestAddArrow_EmitEvent_ReturnsArrow(t *testing.T) {
 	assert.False(t, result.Removed)
 }
 
-func TestAddArrowCmd_ShouldSnapshot_ReturnsFalse(t *testing.T) {
+func TestAddArrowCmd_ShouldSnapshot_ReturnsTrue(t *testing.T) {
 	cmd := AddArrow{Namespace: "github.com/org/repo"}
-	assert.False(t, cmd.ShouldSnapshot())
+	assert.True(t, cmd.ShouldSnapshot())
 }

--- a/internal/app/arrow/internal/commands/begin_execution.go
+++ b/internal/app/arrow/internal/commands/begin_execution.go
@@ -26,7 +26,7 @@ func (c BeginExecution) EventName() string {
 }
 
 func (c BeginExecution) ShouldSnapshot() bool {
-	return false
+	return true
 }
 
 func (c BeginExecution) Validate(current *domainRuntime.ArrowRuntime) error {

--- a/internal/app/arrow/internal/commands/begin_execution_test.go
+++ b/internal/app/arrow/internal/commands/begin_execution_test.go
@@ -52,9 +52,9 @@ func TestBeginExecution_EmitEvent_InstallMethod_SetsInstalling(t *testing.T) {
 	assert.Equal(t, domain.ArrowStateInstalling, result.State)
 }
 
-func TestBeginExecutionCmd_ShouldSnapshot_ReturnsFalse(t *testing.T) {
+func TestBeginExecutionCmd_ShouldSnapshot_ReturnsTrue(t *testing.T) {
 	cmd := BeginExecution{Namespace: "github.com/org/repo"}
-	assert.False(t, cmd.ShouldSnapshot())
+	assert.True(t, cmd.ShouldSnapshot())
 }
 
 func TestBeginExecution_Validate_StopMethod_RequiresRunning(t *testing.T) {

--- a/internal/app/arrow/internal/commands/end_execution.go
+++ b/internal/app/arrow/internal/commands/end_execution.go
@@ -22,7 +22,7 @@ func (c EndExecution) EventName() string {
 }
 
 func (c EndExecution) ShouldSnapshot() bool {
-	return false
+	return true
 }
 
 func (c EndExecution) Validate(current *domainRuntime.ArrowRuntime) error {

--- a/internal/app/arrow/internal/commands/end_execution_test.go
+++ b/internal/app/arrow/internal/commands/end_execution_test.go
@@ -68,9 +68,9 @@ func TestEndExecution_EmitEvent_InstallFailed_SetsAbsent(t *testing.T) {
 	assert.Equal(t, domain.ArrowStateAbsent, result.State)
 }
 
-func TestEndExecutionCmd_ShouldSnapshot_ReturnsFalse(t *testing.T) {
+func TestEndExecutionCmd_ShouldSnapshot_ReturnsTrue(t *testing.T) {
 	cmd := EndExecution{Namespace: "github.com/org/repo"}
-	assert.False(t, cmd.ShouldSnapshot())
+	assert.True(t, cmd.ShouldSnapshot())
 }
 
 func TestEndExecution_EmitEvent_UninstallSuccess_SetsAbsent(t *testing.T) {

--- a/internal/app/arrow/internal/commands/remove.go
+++ b/internal/app/arrow/internal/commands/remove.go
@@ -20,7 +20,7 @@ func (c RemoveArrow) EventName() string {
 }
 
 func (c RemoveArrow) ShouldSnapshot() bool {
-	return false
+	return true
 }
 
 func (c RemoveArrow) Validate(current *domain.Arrow) error {

--- a/internal/app/arrow/internal/commands/remove_test.go
+++ b/internal/app/arrow/internal/commands/remove_test.go
@@ -47,7 +47,7 @@ func TestRemoveArrow_EmitEvent_MarksRemoved(t *testing.T) {
 	assert.True(t, result.Removed)
 }
 
-func TestRemoveArrowCmd_ShouldSnapshot_ReturnsFalse(t *testing.T) {
+func TestRemoveArrowCmd_ShouldSnapshot_ReturnsTrue(t *testing.T) {
 	cmd := RemoveArrow{Namespace: "github.com/org/repo"}
-	assert.False(t, cmd.ShouldSnapshot())
+	assert.True(t, cmd.ShouldSnapshot())
 }

--- a/internal/app/arrow/internal/commands/update_manifest.go
+++ b/internal/app/arrow/internal/commands/update_manifest.go
@@ -21,7 +21,7 @@ func (c UpdateArrowManifest) EventName() string {
 }
 
 func (c UpdateArrowManifest) ShouldSnapshot() bool {
-	return false
+	return true
 }
 
 func (c UpdateArrowManifest) Validate(current *domain.Arrow) error {

--- a/internal/app/arrow/internal/commands/update_manifest_test.go
+++ b/internal/app/arrow/internal/commands/update_manifest_test.go
@@ -49,7 +49,7 @@ func TestUpdateArrowManifest_EmitEvent_UpdatesManifest(t *testing.T) {
 	assert.False(t, result.Removed)
 }
 
-func TestUpdateArrowManifestCmd_ShouldSnapshot_ReturnsFalse(t *testing.T) {
+func TestUpdateArrowManifestCmd_ShouldSnapshot_ReturnsTrue(t *testing.T) {
 	cmd := UpdateArrowManifest{Namespace: "github.com/org/repo"}
-	assert.False(t, cmd.ShouldSnapshot())
+	assert.True(t, cmd.ShouldSnapshot())
 }

--- a/internal/app/quiver/internal/commands/add.go
+++ b/internal/app/quiver/internal/commands/add.go
@@ -21,7 +21,7 @@ func (c AddQuiver) EventName() string {
 }
 
 func (c AddQuiver) ShouldSnapshot() bool {
-	return false
+	return true
 }
 
 func (c AddQuiver) Validate(current *domain.Quiver) error {

--- a/internal/app/quiver/internal/commands/add_test.go
+++ b/internal/app/quiver/internal/commands/add_test.go
@@ -47,7 +47,7 @@ func TestAddQuiver_EmitEvent_ReturnsQuiver(t *testing.T) {
 	assert.False(t, result.Removed)
 }
 
-func TestAddQuiverCmd_ShouldSnapshot_ReturnsFalse(t *testing.T) {
+func TestAddQuiverCmd_ShouldSnapshot_ReturnsTrue(t *testing.T) {
 	cmd := AddQuiver{Namespace: "github.com/org/repo"}
-	assert.False(t, cmd.ShouldSnapshot())
+	assert.True(t, cmd.ShouldSnapshot())
 }

--- a/internal/app/quiver/internal/commands/remove.go
+++ b/internal/app/quiver/internal/commands/remove.go
@@ -20,7 +20,7 @@ func (c RemoveQuiver) EventName() string {
 }
 
 func (c RemoveQuiver) ShouldSnapshot() bool {
-	return false
+	return true
 }
 
 func (c RemoveQuiver) Validate(current *domain.Quiver) error {

--- a/internal/app/quiver/internal/commands/remove_test.go
+++ b/internal/app/quiver/internal/commands/remove_test.go
@@ -47,7 +47,7 @@ func TestRemoveQuiver_EmitEvent_MarksRemoved(t *testing.T) {
 	assert.True(t, result.Removed)
 }
 
-func TestRemoveQuiverCmd_ShouldSnapshot_ReturnsFalse(t *testing.T) {
+func TestRemoveQuiverCmd_ShouldSnapshot_ReturnsTrue(t *testing.T) {
 	cmd := RemoveQuiver{Namespace: "github.com/org/repo"}
-	assert.False(t, cmd.ShouldSnapshot())
+	assert.True(t, cmd.ShouldSnapshot())
 }

--- a/internal/app/quiver/internal/commands/update_manifest.go
+++ b/internal/app/quiver/internal/commands/update_manifest.go
@@ -21,7 +21,7 @@ func (c UpdateQuiverManifest) EventName() string {
 }
 
 func (c UpdateQuiverManifest) ShouldSnapshot() bool {
-	return false
+	return true
 }
 
 func (c UpdateQuiverManifest) Validate(current *domain.Quiver) error {

--- a/internal/app/quiver/internal/commands/update_manifest_test.go
+++ b/internal/app/quiver/internal/commands/update_manifest_test.go
@@ -49,7 +49,7 @@ func TestUpdateQuiverManifest_EmitEvent_UpdatesManifest(t *testing.T) {
 	assert.False(t, result.Removed)
 }
 
-func TestUpdateQuiverManifestCmd_ShouldSnapshot_ReturnsFalse(t *testing.T) {
+func TestUpdateQuiverManifestCmd_ShouldSnapshot_ReturnsTrue(t *testing.T) {
 	cmd := UpdateQuiverManifest{Namespace: "github.com/org/repo"}
-	assert.False(t, cmd.ShouldSnapshot())
+	assert.True(t, cmd.ShouldSnapshot())
 }


### PR DESCRIPTION
## Summary
- `arrow.Add`, `arrow.UpdateManifest`, `arrow.Remove` — now return `true` from `ShouldSnapshot()`
- `runtime.Begin`, `runtime.End` — same
- `quiver.Add`, `quiver.UpdateManifest`, `quiver.Remove` — same
- `runtime.Advance` and `runtime.MarkStopping` unchanged (correctly return `false`)

All 8 affected test functions renamed from `..._ReturnsFalse` to `..._ReturnsTrue` with assertions flipped.

## Test plan
- [x] All 8 `ShouldSnapshot` tests verified RED before fix, GREEN after
- [x] Full test suite passes (`go test ./...`)
- [x] `make pr-checks` passes (91.9% coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)