### PR TITLE
feat(arrow): add media fields (icon, banner) to manifest and catalog responses

### DIFF
--- a/docs/asyncapi/asyncapi.yaml
+++ b/docs/asyncapi/asyncapi.yaml
@@ -171,6 +171,13 @@ components:
           type: array
           items:
             type: string
+        media:
+          type: object
+          properties:
+            icon:
+              type: string
+            banner:
+              type: string
         user_installed:
           type: boolean
           description: true for user-intent arrows; false for transitive dependencies or on "removed".

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -972,6 +972,9 @@ const docTemplate = `{
                 "description": {
                     "type": "string"
                 },
+                "media": {
+                    "$ref": "#/definitions/github_com_rabbytesoftware_quiver_core_internal_domain.ArrowMedia"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -1298,6 +1301,9 @@ const docTemplate = `{
                         "$ref": "#/definitions/github_com_rabbytesoftware_quiver_core_internal_domain.Credit"
                     }
                 },
+                "media": {
+                    "$ref": "#/definitions/github_com_rabbytesoftware_quiver_core_internal_domain.ArrowMedia"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -1339,6 +1345,17 @@ const docTemplate = `{
                     }
                 },
                 "version": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_rabbytesoftware_quiver_core_internal_domain.ArrowMedia": {
+            "type": "object",
+            "properties": {
+                "banner": {
+                    "type": "string"
+                },
+                "icon": {
                     "type": "string"
                 }
             }

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -966,6 +966,9 @@
                 "description": {
                     "type": "string"
                 },
+                "media": {
+                    "$ref": "#/definitions/github_com_rabbytesoftware_quiver_core_internal_domain.ArrowMedia"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -1292,6 +1295,9 @@
                         "$ref": "#/definitions/github_com_rabbytesoftware_quiver_core_internal_domain.Credit"
                     }
                 },
+                "media": {
+                    "$ref": "#/definitions/github_com_rabbytesoftware_quiver_core_internal_domain.ArrowMedia"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -1333,6 +1339,17 @@
                     }
                 },
                 "version": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_rabbytesoftware_quiver_core_internal_domain.ArrowMedia": {
+            "type": "object",
+            "properties": {
+                "banner": {
+                    "type": "string"
+                },
+                "icon": {
                     "type": "string"
                 }
             }

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -59,6 +59,8 @@ definitions:
     properties:
       description:
         type: string
+      media:
+        $ref: '#/definitions/github_com_rabbytesoftware_quiver_core_internal_domain.ArrowMedia'
       name:
         type: string
       namespace:
@@ -272,6 +274,8 @@ definitions:
         items:
           $ref: '#/definitions/github_com_rabbytesoftware_quiver_core_internal_domain.Credit'
         type: array
+      media:
+        $ref: '#/definitions/github_com_rabbytesoftware_quiver_core_internal_domain.ArrowMedia'
       name:
         type: string
       namespace:
@@ -302,6 +306,13 @@ definitions:
           $ref: '#/definitions/github_com_rabbytesoftware_quiver_core_internal_domain.Variable'
         type: array
       version:
+        type: string
+    type: object
+  github_com_rabbytesoftware_quiver_core_internal_domain.ArrowMedia:
+    properties:
+      banner:
+        type: string
+      icon:
         type: string
     type: object
   github_com_rabbytesoftware_quiver_core_internal_domain.ArrowState:

--- a/internal/api/v0/dto/arrow.go
+++ b/internal/api/v0/dto/arrow.go
@@ -6,13 +6,13 @@ import (
 )
 
 type ArrowDTO struct {
-	Namespace     string           `json:"namespace"`
-	Name          string           `json:"name"`
-	Version       string           `json:"version"`
-	Description   string           `json:"description"`
-	Tags          []string         `json:"tags"`
+	Namespace     string            `json:"namespace"`
+	Name          string            `json:"name"`
+	Version       string            `json:"version"`
+	Description   string            `json:"description"`
+	Tags          []string          `json:"tags"`
 	Media         domain.ArrowMedia `json:"media"`
-	UserInstalled bool             `json:"user_installed"`
+	UserInstalled bool              `json:"user_installed"`
 }
 
 func ArrowDTOFrom(a domain.Arrow) ArrowDTO {

--- a/internal/api/v0/dto/arrow.go
+++ b/internal/api/v0/dto/arrow.go
@@ -6,12 +6,13 @@ import (
 )
 
 type ArrowDTO struct {
-	Namespace     string   `json:"namespace"`
-	Name          string   `json:"name"`
-	Version       string   `json:"version"`
-	Description   string   `json:"description"`
-	Tags          []string `json:"tags"`
-	UserInstalled bool     `json:"user_installed"`
+	Namespace     string           `json:"namespace"`
+	Name          string           `json:"name"`
+	Version       string           `json:"version"`
+	Description   string           `json:"description"`
+	Tags          []string         `json:"tags"`
+	Media         domain.ArrowMedia `json:"media"`
+	UserInstalled bool             `json:"user_installed"`
 }
 
 func ArrowDTOFrom(a domain.Arrow) ArrowDTO {
@@ -21,6 +22,7 @@ func ArrowDTOFrom(a domain.Arrow) ArrowDTO {
 		Version:       a.Version,
 		Description:   a.Description,
 		Tags:          a.Tags,
+		Media:         a.Media,
 		UserInstalled: a.UserInstalled,
 	}
 }

--- a/internal/api/v0/dto/arrow_list_item.go
+++ b/internal/api/v0/dto/arrow_list_item.go
@@ -1,6 +1,9 @@
 package dto
 
-import "github.com/rabbytesoftware/quiver.core/internal/app/models"
+import (
+	"github.com/rabbytesoftware/quiver.core/internal/app/models"
+	"github.com/rabbytesoftware/quiver.core/internal/domain"
+)
 
 type InstalledVersionItemDTO struct {
 	Ref         string `json:"ref"`
@@ -15,6 +18,7 @@ type ArrowListItemDTO struct {
 	Name        string                    `json:"name"`
 	Description string                    `json:"description"`
 	Tags        []string                  `json:"tags"`
+	Media       domain.ArrowMedia         `json:"media"`
 	Versions    []InstalledVersionItemDTO `json:"versions"`
 }
 
@@ -36,6 +40,7 @@ func ArrowListItemDTOFrom(
 		Name:        a.Name,
 		Description: a.Description,
 		Tags:        a.Tags,
+		Media:       a.Media,
 		Versions:    versions,
 	}
 }

--- a/internal/api/v0/dto/arrow_list_item_test.go
+++ b/internal/api/v0/dto/arrow_list_item_test.go
@@ -40,3 +40,14 @@ func TestArrowListItemDTOFrom(t *testing.T) {
 	assert.Equal(t, "ready", d.Versions[0].State)
 	assert.Equal(t, "^1.0.0", d.Versions[0].Constraint)
 }
+
+func TestArrowListItemDTOFrom_MediaMapped(t *testing.T) {
+	a := models.ArrowListDTO{
+		Namespace: domain.Namespace("github.com/user/repo"),
+		Name:      "My Arrow",
+		Media:     domain.ArrowMedia{Icon: "https://example.com/icon.png", Banner: "https://example.com/banner.png"},
+	}
+	d := dto.ArrowListItemDTOFrom(a)
+	assert.Equal(t, "https://example.com/icon.png", d.Media.Icon)
+	assert.Equal(t, "https://example.com/banner.png", d.Media.Banner)
+}

--- a/internal/api/v0/dto/arrow_test.go
+++ b/internal/api/v0/dto/arrow_test.go
@@ -77,3 +77,41 @@ func TestArrowDTOFrom(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(dataInstalled), `"user_installed":true`)
 }
+
+func TestArrowDTOFrom_MediaMapped(t *testing.T) {
+	a := domain.Arrow{
+		Namespace: "github.com/user/repo",
+		ArrowMeta: domain.ArrowMeta{
+			Name:    "Test",
+			Version: "1.0.0",
+			Media:   domain.ArrowMedia{Icon: "https://example.com/icon.png", Banner: "https://example.com/banner.png"},
+		},
+	}
+	d := dto.ArrowDTOFrom(a)
+	assert.Equal(t, "https://example.com/icon.png", d.Media.Icon)
+	assert.Equal(t, "https://example.com/banner.png", d.Media.Banner)
+}
+
+func TestArrowEventDTOFrom_UpsertedIncludesMedia(t *testing.T) {
+	evt := hub.ArrowEvent{
+		Kind: hub.CatalogUpserted,
+		Arrow: domain.Arrow{
+			Namespace: "github.com/user/repo@v1.0.0",
+			ArrowMeta: domain.ArrowMeta{
+				Name:    "repo",
+				Version: "v1.0.0",
+				Media:   domain.ArrowMedia{Icon: "https://example.com/icon.png", Banner: "https://example.com/banner.png"},
+			},
+		},
+	}
+	data, err := json.Marshal(dto.ArrowEventDTOFrom(evt))
+	require.NoError(t, err)
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(data, &m))
+
+	media, ok := m["media"].(map[string]any)
+	require.True(t, ok, "media key must be present")
+	assert.Equal(t, "https://example.com/icon.png", media["icon"])
+	assert.Equal(t, "https://example.com/banner.png", media["banner"])
+}

--- a/internal/app/models/arrow_list_dto.go
+++ b/internal/app/models/arrow_list_dto.go
@@ -7,5 +7,6 @@ type ArrowListDTO struct {
 	Name        string                `json:"name"`
 	Description string                `json:"description"`
 	Tags        []string              `json:"tags"`
+	Media       domain.ArrowMedia     `json:"media"`
 	Versions    []InstalledVersionDTO `json:"versions"`
 }

--- a/internal/app/models/mappers/arrow_list_dto.go
+++ b/internal/app/models/mappers/arrow_list_dto.go
@@ -24,6 +24,7 @@ func ArrowListDTOsFrom(
 			Name:        v.Metadata.Name,
 			Description: v.Metadata.Description,
 			Tags:        v.Metadata.Tags,
+			Media:       v.Metadata.Media,
 			Versions:    vDTOs,
 		})
 	}

--- a/internal/app/models/mappers/arrow_list_dto_test.go
+++ b/internal/app/models/mappers/arrow_list_dto_test.go
@@ -16,6 +16,24 @@ func TestArrowListDTOsFrom_Empty(t *testing.T) {
 	assert.Empty(t, result)
 }
 
+func TestArrowListDTOsFrom_MediaMapped(t *testing.T) {
+	views := []models.ArrowView{
+		{
+			Namespace: "github.com/org/repo",
+			Metadata: domain.Arrow{
+				ArrowMeta: domain.ArrowMeta{
+					Name:  "Repo",
+					Media: domain.ArrowMedia{Icon: "https://example.com/icon.png", Banner: "https://example.com/banner.png"},
+				},
+			},
+		},
+	}
+	result := mappers.ArrowListDTOsFrom(views)
+	assert.Len(t, result, 1)
+	assert.Equal(t, "https://example.com/icon.png", result[0].Media.Icon)
+	assert.Equal(t, "https://example.com/banner.png", result[0].Media.Banner)
+}
+
 func TestArrowListDTOsFrom_MapsVersions(t *testing.T) {
 	at := time.Now().UTC()
 	views := []models.ArrowView{

--- a/internal/domain/arrow.go
+++ b/internal/domain/arrow.go
@@ -36,14 +36,20 @@ type Arrow struct {
 }
 
 type ArrowMeta struct {
-	Name        string   `yaml:"name"        json:"name"`
-	Description string   `yaml:"description" json:"description"`
-	Version     string   `yaml:"version"     json:"version"`
-	License     string   `yaml:"license"     json:"license"`
-	URL         string   `yaml:"url"         json:"url"`
-	Maintainers []Credit `yaml:"maintainers" json:"maintainers"`
-	Credits     []Credit `yaml:"credits"     json:"credits"`
-	Tags        []string `yaml:"tags"        json:"tags"`
+	Name        string     `yaml:"name"        json:"name"`
+	Description string     `yaml:"description" json:"description"`
+	Version     string     `yaml:"version"     json:"version"`
+	License     string     `yaml:"license"     json:"license"`
+	URL         string     `yaml:"url"         json:"url"`
+	Maintainers []Credit   `yaml:"maintainers" json:"maintainers"`
+	Credits     []Credit   `yaml:"credits"     json:"credits"`
+	Tags        []string   `yaml:"tags"        json:"tags"`
+	Media       ArrowMedia `yaml:"media"       json:"media"`
+}
+
+type ArrowMedia struct {
+	Icon   string `yaml:"icon"   json:"icon"`
+	Banner string `yaml:"banner" json:"banner"`
 }
 
 type ArrowState string

--- a/internal/engine/manifold/translator/arrow/v0/mapper.go
+++ b/internal/engine/manifold/translator/arrow/v0/mapper.go
@@ -49,6 +49,7 @@ func toAggregate(raw arrowV0) (*domain.Arrow, map[string]models.PrecompiledTarge
 			Maintainers: toCredits(raw.Metadata.Maintainers),
 			Credits:     toCredits(raw.Metadata.Credits),
 			Tags:        raw.Metadata.Tags,
+			Media:       toMedia(raw.Metadata.Media),
 		},
 		Variables: toVariables(raw.Variables),
 		Netbridge: toPorts(raw.Netbridge),
@@ -128,6 +129,13 @@ func toExports(exports map[string]overrideableV0[string]) map[string]step.Overri
 		result[k] = toStepOverrideable(v)
 	}
 	return result
+}
+
+func toMedia(m mediaV0) domain.ArrowMedia {
+	return domain.ArrowMedia{
+		Icon:   m.Icon,
+		Banner: m.Banner,
+	}
 }
 
 func toCredits(credits []creditV0) []domain.Credit {

--- a/internal/engine/manifold/translator/arrow/v0/mapper_test.go
+++ b/internal/engine/manifold/translator/arrow/v0/mapper_test.go
@@ -553,6 +553,58 @@ targets:
 	}
 }
 
+// TestMap_MediaMappedToAggregate: icon and banner from metadata.media survive to domain.ArrowMeta.
+func TestMap_MediaMappedToAggregate(t *testing.T) {
+	yamlData := []byte(`
+schema: "arrow@v0"
+metadata:
+  name: media-test
+  version: 1.0.0
+  media:
+    icon: https://example.com/icon.png
+    banner: https://example.com/banner.png
+targets:
+  "*":
+    lifecycle:
+      install:
+        - type: run
+          command: "echo ok"
+`)
+	result, _, err := v0.New().Parse(yamlData)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if result.Media.Icon != "https://example.com/icon.png" {
+		t.Errorf("Media.Icon = %q, want https://example.com/icon.png", result.Media.Icon)
+	}
+	if result.Media.Banner != "https://example.com/banner.png" {
+		t.Errorf("Media.Banner = %q, want https://example.com/banner.png", result.Media.Banner)
+	}
+}
+
+// TestMap_MediaAbsentYieldsZeroValues: missing media section yields empty strings.
+func TestMap_MediaAbsentYieldsZeroValues(t *testing.T) {
+	yamlData := []byte(`
+schema: "arrow@v0"
+metadata:
+  name: no-media-test
+  version: 1.0.0
+targets:
+  "*":
+    lifecycle:
+      install:
+        - type: run
+          command: "echo ok"
+`)
+	result, _, err := v0.New().Parse(yamlData)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if result.Media.Icon != "" || result.Media.Banner != "" {
+		t.Errorf("expected zero Media, got Icon=%q Banner=%q", result.Media.Icon, result.Media.Banner)
+	}
+}
+
 func TestMap_OverrideableYAML_SequenceNodeError(t *testing.T) {
 	yamlData := []byte(`
 schema: "arrow@v0"


### PR DESCRIPTION
## Summary

- Adds `ArrowMedia` struct (`icon`, `banner`) to `domain.ArrowMeta`
- Wires media through the full v0 response stack: YAML manifest → domain → WS catalog event (`ArrowDTO`) → REST list endpoint (`ArrowListItemDTO`)
- Updates Swagger (regenerated) and AsyncAPI spec (`ArrowEvent` schema)

## Test plan

- [ ] New mapper test: `TestMap_MediaMappedToAggregate` — icon/banner from YAML survive to domain
- [ ] New mapper test: `TestMap_MediaAbsentYieldsZeroValues` — missing `media:` section yields zero values
- [ ] New DTO test: `TestArrowDTOFrom_MediaMapped` — media flows into WS catalog event
- [ ] New DTO test: `TestArrowEventDTOFrom_UpsertedIncludesMedia` — media present in serialized event JSON
- [ ] New DTO test: `TestArrowListItemDTOFrom_MediaMapped` — media flows into REST list response
- [ ] New mapper test: `TestArrowListDTOsFrom_MediaMapped` — media flows through app-layer mapper
- [ ] Full suite green (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)