### PR TITLE
feat(cli/client): QuiverClient interface, types, and FakeClient

### DIFF
--- a/cli/client/client.go
+++ b/cli/client/client.go
@@ -2,42 +2,32 @@ package client
 
 import "context"
 
-// QuiverClient is the boundary between cmd/ and the HTTP+WS transport layer.
-// cmd/ depends only on this interface — never on HTTPClient directly.
 type QuiverClient interface {
-	// Arrow catalog
-	ArrowList(ctx context.Context, userInstalled bool) ([]ArrowListItem, error)
-	ArrowGet(ctx context.Context, ns string) (*ArrowDetail, error)
-	ArrowGetManifest(ctx context.Context, ns string) ([]byte, error)
 	ArrowAdd(ctx context.Context, ns string) error
 	ArrowUpdate(ctx context.Context, ns string) error
 	ArrowRemove(ctx context.Context, ns string) error
+	ArrowList(ctx context.Context, userInstalled bool) ([]ArrowListItem, error)
+	ArrowGet(ctx context.Context, ns string) (*ArrowDetail, error)
+	ArrowGetManifest(ctx context.Context, ns string) ([]byte, error)
 	ArrowSeed(ctx context.Context, ns string, manifest []byte) error
 	ArrowValidate(ctx context.Context, ns string, manifest []byte) (*ValidationResult, error)
 
-	// Runtime lifecycle — fires POST /v0/runtime/:ns/:method then streams ArrowRuntime
-	// snapshots over WS. The channel is closed when the operation reaches its terminal state.
 	Install(ctx context.Context, ns string, vars map[string]string) (<-chan ArrowRuntime, error)
-	Uninstall(ctx context.Context, ns string, vars map[string]string) (<-chan ArrowRuntime, error)
-	Run(ctx context.Context, ns string, vars map[string]string) (<-chan ArrowRuntime, error)
-	Stop(ctx context.Context, ns string) (<-chan ArrowRuntime, error)
 	Update(ctx context.Context, ns string) (<-chan ArrowRuntime, error)
+	Execute(ctx context.Context, ns string, vars map[string]string) (<-chan ArrowRuntime, error)
+	Stop(ctx context.Context, ns string) (<-chan ArrowRuntime, error)
+	Uninstall(ctx context.Context, ns string, vars map[string]string) (<-chan ArrowRuntime, error)
 	RunMethod(ctx context.Context, ns, method string, vars map[string]string) (<-chan ArrowRuntime, error)
 
-	// Runtime observation — streams ArrowRuntime snapshots.
-	// RuntimeGet and RuntimeList dial WS, read one snapshot, then close (no REST GET exists).
-	// WatchRuntime keeps the channel open until ctx is cancelled.
 	RuntimeGet(ctx context.Context, ns string) (*ArrowRuntime, error)
 	RuntimeList(ctx context.Context) ([]ArrowRuntime, error)
 	WatchRuntime(ctx context.Context, ns string) (<-chan ArrowRuntime, error)
 
-	// Collections
-	CollectionList(ctx context.Context) ([]Collection, error)
-	CollectionGet(ctx context.Context, ns string) (*Collection, error)
 	CollectionAdd(ctx context.Context, ns string) error
 	CollectionUpdate(ctx context.Context, ns string) error
 	CollectionRemove(ctx context.Context, ns string) error
+	CollectionList(ctx context.Context) ([]Collection, error)
+	CollectionGet(ctx context.Context, ns string) (*Collection, error)
 
-	// System
 	Health(ctx context.Context) (*HealthStatus, error)
 }

--- a/cli/client/client.go
+++ b/cli/client/client.go
@@ -1,0 +1,43 @@
+package client
+
+import "context"
+
+// QuiverClient is the boundary between cmd/ and the HTTP+WS transport layer.
+// cmd/ depends only on this interface — never on HTTPClient directly.
+type QuiverClient interface {
+	// Arrow catalog
+	ArrowList(ctx context.Context, userInstalled bool) ([]ArrowListItem, error)
+	ArrowGet(ctx context.Context, ns string) (*ArrowDetail, error)
+	ArrowGetManifest(ctx context.Context, ns string) ([]byte, error)
+	ArrowAdd(ctx context.Context, ns string) error
+	ArrowUpdate(ctx context.Context, ns string) error
+	ArrowRemove(ctx context.Context, ns string) error
+	ArrowSeed(ctx context.Context, ns string, manifest []byte) error
+	ArrowValidate(ctx context.Context, ns string, manifest []byte) (*ValidationResult, error)
+
+	// Runtime lifecycle — fires POST /v0/runtime/:ns/:method then streams ArrowRuntime
+	// snapshots over WS. The channel is closed when the operation reaches its terminal state.
+	Install(ctx context.Context, ns string, vars map[string]string) (<-chan ArrowRuntime, error)
+	Uninstall(ctx context.Context, ns string, vars map[string]string) (<-chan ArrowRuntime, error)
+	Run(ctx context.Context, ns string, vars map[string]string) (<-chan ArrowRuntime, error)
+	Stop(ctx context.Context, ns string) (<-chan ArrowRuntime, error)
+	Update(ctx context.Context, ns string) (<-chan ArrowRuntime, error)
+	RunMethod(ctx context.Context, ns, method string, vars map[string]string) (<-chan ArrowRuntime, error)
+
+	// Runtime observation — streams ArrowRuntime snapshots.
+	// RuntimeGet and RuntimeList dial WS, read one snapshot, then close (no REST GET exists).
+	// WatchRuntime keeps the channel open until ctx is cancelled.
+	RuntimeGet(ctx context.Context, ns string) (*ArrowRuntime, error)
+	RuntimeList(ctx context.Context) ([]ArrowRuntime, error)
+	WatchRuntime(ctx context.Context, ns string) (<-chan ArrowRuntime, error)
+
+	// Collections
+	CollectionList(ctx context.Context) ([]Collection, error)
+	CollectionGet(ctx context.Context, ns string) (*Collection, error)
+	CollectionAdd(ctx context.Context, ns string) error
+	CollectionUpdate(ctx context.Context, ns string) error
+	CollectionRemove(ctx context.Context, ns string) error
+
+	// System
+	Health(ctx context.Context) (*HealthStatus, error)
+}

--- a/cli/client/fake.go
+++ b/cli/client/fake.go
@@ -1,0 +1,214 @@
+package client
+
+import "context"
+
+// FakeClient implements QuiverClient for use in unit tests.
+// Set only the Fn fields your test needs; unset fields return zero values.
+// Lifecycle and watch methods with unset Fn return a closed, empty channel.
+type FakeClient struct {
+	ArrowListFn        func(ctx context.Context, userInstalled bool) ([]ArrowListItem, error)
+	ArrowGetFn         func(ctx context.Context, ns string) (*ArrowDetail, error)
+	ArrowGetManifestFn func(ctx context.Context, ns string) ([]byte, error)
+	ArrowAddFn         func(ctx context.Context, ns string) error
+	ArrowUpdateFn      func(ctx context.Context, ns string) error
+	ArrowRemoveFn      func(ctx context.Context, ns string) error
+	ArrowSeedFn        func(ctx context.Context, ns string, manifest []byte) error
+	ArrowValidateFn    func(ctx context.Context, ns string, manifest []byte) (*ValidationResult, error)
+
+	InstallFn   func(ctx context.Context, ns string, vars map[string]string) (<-chan ArrowRuntime, error)
+	UninstallFn func(ctx context.Context, ns string, vars map[string]string) (<-chan ArrowRuntime, error)
+	RunFn       func(ctx context.Context, ns string, vars map[string]string) (<-chan ArrowRuntime, error)
+	StopFn      func(ctx context.Context, ns string) (<-chan ArrowRuntime, error)
+	UpdateFn    func(ctx context.Context, ns string) (<-chan ArrowRuntime, error)
+	RunMethodFn func(ctx context.Context, ns, method string, vars map[string]string) (<-chan ArrowRuntime, error)
+
+	RuntimeGetFn   func(ctx context.Context, ns string) (*ArrowRuntime, error)
+	RuntimeListFn  func(ctx context.Context) ([]ArrowRuntime, error)
+	WatchRuntimeFn func(ctx context.Context, ns string) (<-chan ArrowRuntime, error)
+
+	CollectionListFn   func(ctx context.Context) ([]Collection, error)
+	CollectionGetFn    func(ctx context.Context, ns string) (*Collection, error)
+	CollectionAddFn    func(ctx context.Context, ns string) error
+	CollectionUpdateFn func(ctx context.Context, ns string) error
+	CollectionRemoveFn func(ctx context.Context, ns string) error
+
+	HealthFn func(ctx context.Context) (*HealthStatus, error)
+}
+
+// StreamOf returns a closed, buffered channel pre-loaded with the given snapshots.
+// Use it to script lifecycle and watch responses in unit tests.
+func StreamOf(snapshots ...ArrowRuntime) <-chan ArrowRuntime {
+	ch := make(chan ArrowRuntime, len(snapshots))
+	for _, s := range snapshots {
+		ch <- s
+	}
+	close(ch)
+	return ch
+}
+
+func closedCh() <-chan ArrowRuntime {
+	ch := make(chan ArrowRuntime)
+	close(ch)
+	return ch
+}
+
+func (f *FakeClient) ArrowList(ctx context.Context, userInstalled bool) ([]ArrowListItem, error) {
+	if f.ArrowListFn != nil {
+		return f.ArrowListFn(ctx, userInstalled)
+	}
+	return nil, nil
+}
+
+func (f *FakeClient) ArrowGet(ctx context.Context, ns string) (*ArrowDetail, error) {
+	if f.ArrowGetFn != nil {
+		return f.ArrowGetFn(ctx, ns)
+	}
+	return nil, nil
+}
+
+func (f *FakeClient) ArrowGetManifest(ctx context.Context, ns string) ([]byte, error) {
+	if f.ArrowGetManifestFn != nil {
+		return f.ArrowGetManifestFn(ctx, ns)
+	}
+	return nil, nil
+}
+
+func (f *FakeClient) ArrowAdd(ctx context.Context, ns string) error {
+	if f.ArrowAddFn != nil {
+		return f.ArrowAddFn(ctx, ns)
+	}
+	return nil
+}
+
+func (f *FakeClient) ArrowUpdate(ctx context.Context, ns string) error {
+	if f.ArrowUpdateFn != nil {
+		return f.ArrowUpdateFn(ctx, ns)
+	}
+	return nil
+}
+
+func (f *FakeClient) ArrowRemove(ctx context.Context, ns string) error {
+	if f.ArrowRemoveFn != nil {
+		return f.ArrowRemoveFn(ctx, ns)
+	}
+	return nil
+}
+
+func (f *FakeClient) ArrowSeed(ctx context.Context, ns string, manifest []byte) error {
+	if f.ArrowSeedFn != nil {
+		return f.ArrowSeedFn(ctx, ns, manifest)
+	}
+	return nil
+}
+
+func (f *FakeClient) ArrowValidate(ctx context.Context, ns string, manifest []byte) (*ValidationResult, error) {
+	if f.ArrowValidateFn != nil {
+		return f.ArrowValidateFn(ctx, ns, manifest)
+	}
+	return nil, nil
+}
+
+func (f *FakeClient) Install(ctx context.Context, ns string, vars map[string]string) (<-chan ArrowRuntime, error) {
+	if f.InstallFn != nil {
+		return f.InstallFn(ctx, ns, vars)
+	}
+	return closedCh(), nil
+}
+
+func (f *FakeClient) Uninstall(ctx context.Context, ns string, vars map[string]string) (<-chan ArrowRuntime, error) {
+	if f.UninstallFn != nil {
+		return f.UninstallFn(ctx, ns, vars)
+	}
+	return closedCh(), nil
+}
+
+func (f *FakeClient) Run(ctx context.Context, ns string, vars map[string]string) (<-chan ArrowRuntime, error) {
+	if f.RunFn != nil {
+		return f.RunFn(ctx, ns, vars)
+	}
+	return closedCh(), nil
+}
+
+func (f *FakeClient) Stop(ctx context.Context, ns string) (<-chan ArrowRuntime, error) {
+	if f.StopFn != nil {
+		return f.StopFn(ctx, ns)
+	}
+	return closedCh(), nil
+}
+
+func (f *FakeClient) Update(ctx context.Context, ns string) (<-chan ArrowRuntime, error) {
+	if f.UpdateFn != nil {
+		return f.UpdateFn(ctx, ns)
+	}
+	return closedCh(), nil
+}
+
+func (f *FakeClient) RunMethod(ctx context.Context, ns, method string, vars map[string]string) (<-chan ArrowRuntime, error) {
+	if f.RunMethodFn != nil {
+		return f.RunMethodFn(ctx, ns, method, vars)
+	}
+	return closedCh(), nil
+}
+
+func (f *FakeClient) RuntimeGet(ctx context.Context, ns string) (*ArrowRuntime, error) {
+	if f.RuntimeGetFn != nil {
+		return f.RuntimeGetFn(ctx, ns)
+	}
+	return nil, nil
+}
+
+func (f *FakeClient) RuntimeList(ctx context.Context) ([]ArrowRuntime, error) {
+	if f.RuntimeListFn != nil {
+		return f.RuntimeListFn(ctx)
+	}
+	return nil, nil
+}
+
+func (f *FakeClient) WatchRuntime(ctx context.Context, ns string) (<-chan ArrowRuntime, error) {
+	if f.WatchRuntimeFn != nil {
+		return f.WatchRuntimeFn(ctx, ns)
+	}
+	return closedCh(), nil
+}
+
+func (f *FakeClient) CollectionList(ctx context.Context) ([]Collection, error) {
+	if f.CollectionListFn != nil {
+		return f.CollectionListFn(ctx)
+	}
+	return nil, nil
+}
+
+func (f *FakeClient) CollectionGet(ctx context.Context, ns string) (*Collection, error) {
+	if f.CollectionGetFn != nil {
+		return f.CollectionGetFn(ctx, ns)
+	}
+	return nil, nil
+}
+
+func (f *FakeClient) CollectionAdd(ctx context.Context, ns string) error {
+	if f.CollectionAddFn != nil {
+		return f.CollectionAddFn(ctx, ns)
+	}
+	return nil
+}
+
+func (f *FakeClient) CollectionUpdate(ctx context.Context, ns string) error {
+	if f.CollectionUpdateFn != nil {
+		return f.CollectionUpdateFn(ctx, ns)
+	}
+	return nil
+}
+
+func (f *FakeClient) CollectionRemove(ctx context.Context, ns string) error {
+	if f.CollectionRemoveFn != nil {
+		return f.CollectionRemoveFn(ctx, ns)
+	}
+	return nil
+}
+
+func (f *FakeClient) Health(ctx context.Context) (*HealthStatus, error) {
+	if f.HealthFn != nil {
+		return f.HealthFn(ctx)
+	}
+	return nil, nil
+}

--- a/cli/client/fake_test.go
+++ b/cli/client/fake_test.go
@@ -1,0 +1,155 @@
+package client_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"quiver-cli/client"
+)
+
+// Compile-time assertion: *FakeClient must satisfy QuiverClient.
+var _ client.QuiverClient = (*client.FakeClient)(nil)
+
+func TestFakeClient_UnsetFns_ReturnZeroValues(t *testing.T) {
+	ctx := context.Background()
+	f := &client.FakeClient{}
+
+	items, err := f.ArrowList(ctx, true)
+	assert.NoError(t, err)
+	assert.Nil(t, items)
+
+	detail, err := f.ArrowGet(ctx, "ns")
+	assert.NoError(t, err)
+	assert.Nil(t, detail)
+
+	manifest, err := f.ArrowGetManifest(ctx, "ns")
+	assert.NoError(t, err)
+	assert.Nil(t, manifest)
+
+	assert.NoError(t, f.ArrowAdd(ctx, "ns"))
+	assert.NoError(t, f.ArrowUpdate(ctx, "ns"))
+	assert.NoError(t, f.ArrowRemove(ctx, "ns"))
+	assert.NoError(t, f.ArrowSeed(ctx, "ns", nil))
+
+	vr, err := f.ArrowValidate(ctx, "ns", nil)
+	assert.NoError(t, err)
+	assert.Nil(t, vr)
+
+	rt, err := f.RuntimeGet(ctx, "ns")
+	assert.NoError(t, err)
+	assert.Nil(t, rt)
+
+	rts, err := f.RuntimeList(ctx)
+	assert.NoError(t, err)
+	assert.Nil(t, rts)
+
+	cols, err := f.CollectionList(ctx)
+	assert.NoError(t, err)
+	assert.Nil(t, cols)
+
+	col, err := f.CollectionGet(ctx, "ns")
+	assert.NoError(t, err)
+	assert.Nil(t, col)
+
+	assert.NoError(t, f.CollectionAdd(ctx, "ns"))
+	assert.NoError(t, f.CollectionUpdate(ctx, "ns"))
+	assert.NoError(t, f.CollectionRemove(ctx, "ns"))
+
+	health, err := f.Health(ctx)
+	assert.NoError(t, err)
+	assert.Nil(t, health)
+}
+
+func TestFakeClient_UnsetLifecycleFns_ReturnClosedEmptyChannel(t *testing.T) {
+	ctx := context.Background()
+	f := &client.FakeClient{}
+
+	for _, ch := range []func() (<-chan client.ArrowRuntime, error){
+		func() (<-chan client.ArrowRuntime, error) { return f.Install(ctx, "ns", nil) },
+		func() (<-chan client.ArrowRuntime, error) { return f.Uninstall(ctx, "ns", nil) },
+		func() (<-chan client.ArrowRuntime, error) { return f.Run(ctx, "ns", nil) },
+		func() (<-chan client.ArrowRuntime, error) { return f.Stop(ctx, "ns") },
+		func() (<-chan client.ArrowRuntime, error) { return f.Update(ctx, "ns") },
+		func() (<-chan client.ArrowRuntime, error) { return f.RunMethod(ctx, "ns", "custom", nil) },
+		func() (<-chan client.ArrowRuntime, error) { return f.WatchRuntime(ctx, "ns") },
+	} {
+		got, err := ch()
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		var snapshots []client.ArrowRuntime
+		for s := range got {
+			snapshots = append(snapshots, s)
+		}
+		assert.Empty(t, snapshots)
+	}
+}
+
+func TestFakeClient_SetFn_IsCalled(t *testing.T) {
+	ctx := context.Background()
+	called := false
+
+	f := &client.FakeClient{
+		ArrowListFn: func(_ context.Context, userInstalled bool) ([]client.ArrowListItem, error) {
+			called = true
+			assert.True(t, userInstalled)
+			return []client.ArrowListItem{{Namespace: "github.com/foo/bar"}}, nil
+		},
+	}
+
+	items, err := f.ArrowList(ctx, true)
+	require.NoError(t, err)
+	assert.True(t, called)
+	require.Len(t, items, 1)
+	assert.Equal(t, "github.com/foo/bar", items[0].Namespace)
+}
+
+func TestFakeClient_InstallFn_StreamsSnapshots(t *testing.T) {
+	ctx := context.Background()
+	expected := []client.ArrowRuntime{
+		{Namespace: "github.com/foo/bar", State: "installing"},
+		{Namespace: "github.com/foo/bar", State: "ready"},
+	}
+
+	f := &client.FakeClient{
+		InstallFn: func(_ context.Context, ns string, _ map[string]string) (<-chan client.ArrowRuntime, error) {
+			assert.Equal(t, "github.com/foo/bar", ns)
+			return client.StreamOf(expected...), nil
+		},
+	}
+
+	ch, err := f.Install(ctx, "github.com/foo/bar", nil)
+	require.NoError(t, err)
+
+	var got []client.ArrowRuntime
+	for s := range ch {
+		got = append(got, s)
+	}
+	assert.Equal(t, expected, got)
+}
+
+func TestStreamOf_DeliversSnapshotsInOrder(t *testing.T) {
+	snapshots := []client.ArrowRuntime{
+		{Namespace: "a", State: "installing"},
+		{Namespace: "a", State: "ready"},
+	}
+
+	ch := client.StreamOf(snapshots...)
+
+	var got []client.ArrowRuntime
+	for s := range ch {
+		got = append(got, s)
+	}
+	assert.Equal(t, snapshots, got)
+}
+
+func TestStreamOf_Empty_ReturnsClosedChannel(t *testing.T) {
+	ch := client.StreamOf()
+	var got []client.ArrowRuntime
+	for s := range ch {
+		got = append(got, s)
+	}
+	assert.Empty(t, got)
+}

--- a/cli/client/types.go
+++ b/cli/client/types.go
@@ -1,0 +1,107 @@
+package client
+
+// ArrowRuntime is the full runtime state snapshot pushed by the WS stream.
+// Mirrors the server's ArrowRuntimeDTO.
+type ArrowRuntime struct {
+	Namespace  string
+	State      string
+	ActiveRun  *RunRecord
+	LastReturn *Return
+}
+
+// RunRecord holds the current execution context.
+// Mirrors the server's RunRecordDTO.
+type RunRecord struct {
+	Method    string
+	PID       int
+	Variables map[string]string
+	Steps     []StepProgress
+}
+
+// StepProgress is the status of one execution step.
+// Mirrors the server's StepProgressDTO.
+type StepProgress struct {
+	Index  int
+	Status string // pending | running | completed | failed
+	Title  string
+	Type   string
+	Error  *string
+}
+
+// Return holds the result of a completed execution.
+// Mirrors the server's ReturnDTO.
+type Return struct {
+	Method    string
+	Outcome   string // success | failed | cancelled
+	Variables map[string]string
+	Steps     []StepProgress
+}
+
+// ArrowListItem is one entry in the arrow catalog list.
+// Mirrors the server's ArrowListItemDTO.
+type ArrowListItem struct {
+	Namespace   string
+	Name        string
+	Description string
+	Tags        []string
+	Versions    []InstalledVersion
+}
+
+// InstalledVersion is one installed ref of an arrow.
+// Mirrors the server's InstalledVersionItemDTO.
+type InstalledVersion struct {
+	Ref         string
+	Version     string
+	State       string
+	InstalledAt string
+	Constraint  string
+}
+
+// ArrowDetail is the full detail view of a catalog entry.
+// Mirrors the server's ArrowDetailDTO.
+type ArrowDetail struct {
+	Namespace           string
+	Name                string
+	Version             string
+	Description         string
+	License             string
+	State               string
+	Tags                []string
+	InstalledRef        string
+	InstalledAt         string
+	InstalledConstraint string
+	UserInstalled       bool
+	ActiveRun           *RunRecord
+	LastReturn          *Return
+}
+
+// ValidationResult is the response from the manifest validate endpoint.
+// Mirrors the server's ValidationResultDTO.
+type ValidationResult struct {
+	Valid                bool
+	Errors               []ValidationError
+	SupportedPlatforms   []string
+	UnsupportedPlatforms []string
+}
+
+// ValidationError is one validation failure.
+// Mirrors the server's ValidationErrorDTO.
+type ValidationError struct {
+	Field   string
+	Rule    string
+	Message string
+}
+
+// Collection is a Quiver collection (renamed from "Quiver" per CLI spec v2 changelog).
+// Mirrors the server's QuiverListItemDTO.
+type Collection struct {
+	Namespace   string
+	Name        string
+	Description string
+	Tags        []string
+}
+
+// HealthStatus is the response from the health endpoint.
+type HealthStatus struct {
+	Status string
+}

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,0 +1,11 @@
+module quiver-cli
+
+go 1.26.2
+
+require github.com/stretchr/testify v1.11.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Summary
- Defines `QuiverClient` — the interface boundary between `cmd/` and the HTTP+WS transport layer
- Defines all shared CLI types that mirror the server DTO JSON shapes
- Implements `FakeClient` (function-field test double) and `StreamOf` helper for unit-testing `cmd/` without a running daemon

## Test plan
- [ ] `cd cli && go test ./client/ -v -race` — all 6 unit tests pass
- [ ] Review interface shape against `docs/superpowers/specs/2026-05-11-cli-client-interface-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)