### PR TITLE
feat(api): expose runtime state over REST GET endpoints

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -815,6 +815,100 @@ const docTemplate = `{
                 }
             }
         },
+        "/runtime": {
+            "get": {
+                "description": "Returns the current runtime state of every arrow in the catalog. Arrows that have never been installed report state \"absent\". Use the WebSocket upgrade on the same route to stream updates instead.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "runtime"
+                ],
+                "summary": "List runtimes",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/github_com_rabbytesoftware_quiver_core_internal_api_libs.QueryResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/github_com_rabbytesoftware_quiver_core_internal_api_v0_dto.ArrowRuntimeDTO"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rabbytesoftware_quiver_core_internal_api_libs.ErrResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/runtime/{ns}": {
+            "get": {
+                "description": "Returns the current runtime state for an arrow, including the active execution and the last completed return. Use the WebSocket upgrade on the same route to stream updates instead.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "runtime"
+                ],
+                "summary": "Get runtime",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Arrow namespace",
+                        "name": "ns",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/github_com_rabbytesoftware_quiver_core_internal_api_libs.QueryResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/github_com_rabbytesoftware_quiver_core_internal_api_v0_dto.ArrowRuntimeDTO"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Arrow not found",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rabbytesoftware_quiver_core_internal_api_libs.ErrResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rabbytesoftware_quiver_core_internal_api_libs.ErrResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/runtime/{ns}/{method}": {
             "post": {
                 "description": "Triggers a lifecycle method on an arrow (install, uninstall, execute, stop, update, or any custom method defined in the manifest). Returns 202 Accepted immediately; progress is streamed via WebSocket.",
@@ -1029,6 +1123,23 @@ const docTemplate = `{
                     }
                 },
                 "version": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_rabbytesoftware_quiver_core_internal_api_v0_dto.ArrowRuntimeDTO": {
+            "type": "object",
+            "properties": {
+                "active_run": {
+                    "$ref": "#/definitions/github_com_rabbytesoftware_quiver_core_internal_api_v0_dto.RunRecordDTO"
+                },
+                "last_return": {
+                    "$ref": "#/definitions/github_com_rabbytesoftware_quiver_core_internal_api_v0_dto.ReturnDTO"
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "state": {
                     "type": "string"
                 }
             }

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -809,6 +809,100 @@
                 }
             }
         },
+        "/runtime": {
+            "get": {
+                "description": "Returns the current runtime state of every arrow in the catalog. Arrows that have never been installed report state \"absent\". Use the WebSocket upgrade on the same route to stream updates instead.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "runtime"
+                ],
+                "summary": "List runtimes",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/github_com_rabbytesoftware_quiver_core_internal_api_libs.QueryResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/github_com_rabbytesoftware_quiver_core_internal_api_v0_dto.ArrowRuntimeDTO"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rabbytesoftware_quiver_core_internal_api_libs.ErrResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/runtime/{ns}": {
+            "get": {
+                "description": "Returns the current runtime state for an arrow, including the active execution and the last completed return. Use the WebSocket upgrade on the same route to stream updates instead.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "runtime"
+                ],
+                "summary": "Get runtime",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Arrow namespace",
+                        "name": "ns",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/github_com_rabbytesoftware_quiver_core_internal_api_libs.QueryResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/github_com_rabbytesoftware_quiver_core_internal_api_v0_dto.ArrowRuntimeDTO"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Arrow not found",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rabbytesoftware_quiver_core_internal_api_libs.ErrResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_rabbytesoftware_quiver_core_internal_api_libs.ErrResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/runtime/{ns}/{method}": {
             "post": {
                 "description": "Triggers a lifecycle method on an arrow (install, uninstall, execute, stop, update, or any custom method defined in the manifest). Returns 202 Accepted immediately; progress is streamed via WebSocket.",
@@ -1023,6 +1117,23 @@
                     }
                 },
                 "version": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_rabbytesoftware_quiver_core_internal_api_v0_dto.ArrowRuntimeDTO": {
+            "type": "object",
+            "properties": {
+                "active_run": {
+                    "$ref": "#/definitions/github_com_rabbytesoftware_quiver_core_internal_api_v0_dto.RunRecordDTO"
+                },
+                "last_return": {
+                    "$ref": "#/definitions/github_com_rabbytesoftware_quiver_core_internal_api_v0_dto.ReturnDTO"
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "state": {
                     "type": "string"
                 }
             }

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -99,6 +99,17 @@ definitions:
       version:
         type: string
     type: object
+  github_com_rabbytesoftware_quiver_core_internal_api_v0_dto.ArrowRuntimeDTO:
+    properties:
+      active_run:
+        $ref: '#/definitions/github_com_rabbytesoftware_quiver_core_internal_api_v0_dto.RunRecordDTO'
+      last_return:
+        $ref: '#/definitions/github_com_rabbytesoftware_quiver_core_internal_api_v0_dto.ReturnDTO'
+      namespace:
+        type: string
+      state:
+        type: string
+    type: object
   github_com_rabbytesoftware_quiver_core_internal_api_v0_dto.CollectionArrowDTO:
     properties:
       description:
@@ -997,6 +1008,66 @@ paths:
       summary: Health check
       tags:
       - system
+  /runtime:
+    get:
+      description: Returns the current runtime state of every arrow in the catalog.
+        Arrows that have never been installed report state "absent". Use the WebSocket
+        upgrade on the same route to stream updates instead.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/github_com_rabbytesoftware_quiver_core_internal_api_libs.QueryResponse'
+            - properties:
+                data:
+                  items:
+                    $ref: '#/definitions/github_com_rabbytesoftware_quiver_core_internal_api_v0_dto.ArrowRuntimeDTO'
+                  type: array
+              type: object
+        "500":
+          description: Internal error
+          schema:
+            $ref: '#/definitions/github_com_rabbytesoftware_quiver_core_internal_api_libs.ErrResponse'
+      summary: List runtimes
+      tags:
+      - runtime
+  /runtime/{ns}:
+    get:
+      description: Returns the current runtime state for an arrow, including the active
+        execution and the last completed return. Use the WebSocket upgrade on the
+        same route to stream updates instead.
+      parameters:
+      - description: Arrow namespace
+        in: path
+        name: ns
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/github_com_rabbytesoftware_quiver_core_internal_api_libs.QueryResponse'
+            - properties:
+                data:
+                  $ref: '#/definitions/github_com_rabbytesoftware_quiver_core_internal_api_v0_dto.ArrowRuntimeDTO'
+              type: object
+        "404":
+          description: Arrow not found
+          schema:
+            $ref: '#/definitions/github_com_rabbytesoftware_quiver_core_internal_api_libs.ErrResponse'
+        "500":
+          description: Internal error
+          schema:
+            $ref: '#/definitions/github_com_rabbytesoftware_quiver_core_internal_api_libs.ErrResponse'
+      summary: Get runtime
+      tags:
+      - runtime
   /runtime/{ns}/{method}:
     post:
       consumes:

--- a/internal/api/mocks/runtime_service.go
+++ b/internal/api/mocks/runtime_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/rabbytesoftware/quiver.core/internal/domain"
+	domainRuntime "github.com/rabbytesoftware/quiver.core/internal/domain/runtime"
 )
 
 type RuntimeService struct {
@@ -13,6 +14,23 @@ type RuntimeService struct {
 	StopErr             error
 	RuntimeExistsResult bool
 	RuntimeExistsErr    error
+	GetRuntimeResult    *domainRuntime.ArrowRuntime
+	GetRuntimeErr       error
+	ListRuntimesResult  []domainRuntime.ArrowRuntime
+	ListRuntimesErr     error
+}
+
+func (m *RuntimeService) GetRuntime(
+	_ context.Context,
+	_ domain.Namespace,
+) (*domainRuntime.ArrowRuntime, error) {
+	return m.GetRuntimeResult, m.GetRuntimeErr
+}
+
+func (m *RuntimeService) ListRuntimes(
+	_ context.Context,
+) ([]domainRuntime.ArrowRuntime, error) {
+	return m.ListRuntimesResult, m.ListRuntimesErr
 }
 
 func (m *RuntimeService) Install(

--- a/internal/api/v0/endpoints/runtime/handlers/handlers.go
+++ b/internal/api/v0/endpoints/runtime/handlers/handlers.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rabbytesoftware/quiver.core/internal/api/libs"
 	"github.com/rabbytesoftware/quiver.core/internal/api/libs/apierr"
 	apidto "github.com/rabbytesoftware/quiver.core/internal/api/v0/dto"
+	apperrors "github.com/rabbytesoftware/quiver.core/internal/app/errors"
 	"github.com/rabbytesoftware/quiver.core/internal/app/usecases"
 	"github.com/rabbytesoftware/quiver.core/internal/domain"
 )
@@ -66,4 +67,56 @@ func (h *Handlers) Execute(c *gin.Context) {
 		return
 	}
 	libs.WriteMutationOK(c, http.StatusAccepted, string(ns))
+}
+
+// Get returns the runtime snapshot for a single arrow.
+//
+// @Summary      Get runtime
+// @Description  Returns the current runtime state for an arrow, including the active execution and the last completed return. Use the WebSocket upgrade on the same route to stream updates instead.
+// @Tags         runtime
+// @Produce      json
+// @Param        ns   path  string  true  "Arrow namespace"
+// @Success      200  {object}  libs.QueryResponse{data=apidto.ArrowRuntimeDTO}
+// @Failure      404  {object}  libs.ErrResponse  "Arrow not found"
+// @Failure      500  {object}  libs.ErrResponse  "Internal error"
+// @Router       /runtime/{ns} [get]
+func (h *Handlers) Get(c *gin.Context) {
+	ns := domain.Namespace(c.Param("ns"))
+
+	rt, err := h.svc.GetRuntime(c.Request.Context(), ns)
+	if err != nil {
+		status, msg := apierr.StatusAndMessage(err)
+		libs.WriteErr(c, status, msg, string(ns))
+		return
+	}
+	if rt == nil {
+		status, msg := apierr.StatusAndMessage(apperrors.ErrNotFound)
+		libs.WriteErr(c, status, msg, string(ns))
+		return
+	}
+	libs.WriteQueryOK(c, apidto.ArrowRuntimeDTOFrom(*rt))
+}
+
+// List returns runtime snapshots for every arrow in the catalog.
+//
+// @Summary      List runtimes
+// @Description  Returns the current runtime state of every arrow in the catalog. Arrows that have never been installed report state "absent". Use the WebSocket upgrade on the same route to stream updates instead.
+// @Tags         runtime
+// @Produce      json
+// @Success      200  {object}  libs.QueryResponse{data=[]apidto.ArrowRuntimeDTO}
+// @Failure      500  {object}  libs.ErrResponse  "Internal error"
+// @Router       /runtime [get]
+func (h *Handlers) List(c *gin.Context) {
+	runtimes, err := h.svc.ListRuntimes(c.Request.Context())
+	if err != nil {
+		status, msg := apierr.StatusAndMessage(err)
+		libs.WriteErr(c, status, msg, "")
+		return
+	}
+
+	dtos := make([]apidto.ArrowRuntimeDTO, 0, len(runtimes))
+	for _, rt := range runtimes {
+		dtos = append(dtos, apidto.ArrowRuntimeDTOFrom(rt))
+	}
+	libs.WriteQueryOK(c, dtos)
 }

--- a/internal/api/v0/endpoints/runtime/handlers/handlers_test.go
+++ b/internal/api/v0/endpoints/runtime/handlers/handlers_test.go
@@ -2,6 +2,7 @@ package handlers_test
 
 import (
 	"bytes"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -13,6 +14,8 @@ import (
 	"github.com/rabbytesoftware/quiver.core/internal/api/mocks"
 	"github.com/rabbytesoftware/quiver.core/internal/api/v0/endpoints/runtime/handlers"
 	apperrors "github.com/rabbytesoftware/quiver.core/internal/app/errors"
+	"github.com/rabbytesoftware/quiver.core/internal/domain"
+	domainRuntime "github.com/rabbytesoftware/quiver.core/internal/domain/runtime"
 )
 
 func TestMain(m *testing.M) {
@@ -21,6 +24,8 @@ func TestMain(m *testing.M) {
 }
 
 const encodedNS = "/v0/runtime/github.com%2Fuser%2Frepo"
+
+var errTestBoom = errors.New("boom")
 
 func setup(rt *mocks.RuntimeService) (*handlers.Handlers, *gin.Engine) {
 	if rt == nil {
@@ -135,4 +140,98 @@ func TestInstall_MethodNotFound_Returns404(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, encodedNS+"/install", nil))
 	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// ─── GET /runtime/:ns and GET /runtime ──────────────────────────────────────
+
+func setupGet(rt *mocks.RuntimeService) *gin.Engine {
+	if rt == nil {
+		rt = &mocks.RuntimeService{}
+	}
+	h := handlers.New(rt)
+	r := gin.New()
+	r.UseRawPath = true
+	r.UnescapePathValues = true
+	r.GET("/v0/runtime", h.List)
+	r.GET("/v0/runtime/:ns", h.Get)
+	return r
+}
+
+func TestGet_ReturnsRuntime(t *testing.T) {
+	rt := &mocks.RuntimeService{
+		GetRuntimeResult: &domainRuntime.ArrowRuntime{
+			Ref:   "github.com/user/repo",
+			State: domain.ArrowStateRunning,
+		},
+	}
+	r := setupGet(rt)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, encodedNS, nil))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"success":true`)
+	assert.Contains(t, w.Body.String(), `"state":"running"`)
+	assert.Contains(t, w.Body.String(), `"namespace":"github.com/user/repo"`)
+}
+
+func TestGet_NotFound(t *testing.T) {
+	rt := &mocks.RuntimeService{GetRuntimeErr: apperrors.ErrNotFound}
+	r := setupGet(rt)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, encodedNS, nil))
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Contains(t, w.Body.String(), `"success":false`)
+}
+
+func TestGet_InternalError(t *testing.T) {
+	rt := &mocks.RuntimeService{GetRuntimeErr: errTestBoom}
+	r := setupGet(rt)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, encodedNS, nil))
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestList_ReturnsRuntimes(t *testing.T) {
+	rt := &mocks.RuntimeService{
+		ListRuntimesResult: []domainRuntime.ArrowRuntime{
+			{Ref: "github.com/user/a@v1", State: domain.ArrowStateRunning},
+			{Ref: "github.com/user/b@v1", State: domain.ArrowStateAbsent},
+		},
+	}
+	r := setupGet(rt)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v0/runtime", nil))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"github.com/user/a@v1"`)
+	assert.Contains(t, w.Body.String(), `"github.com/user/b@v1"`)
+}
+
+func TestList_EmptyReturnsArray(t *testing.T) {
+	r := setupGet(nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v0/runtime", nil))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"data":[]`)
+}
+
+func TestList_InternalError(t *testing.T) {
+	rt := &mocks.RuntimeService{ListRuntimesErr: errTestBoom}
+	r := setupGet(rt)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v0/runtime", nil))
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestGet_NilRuntimeReturnsNotFound(t *testing.T) {
+	r := setupGet(&mocks.RuntimeService{})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, encodedNS, nil))
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Contains(t, w.Body.String(), `"success":false`)
 }

--- a/internal/api/v0/endpoints/runtime/routes.go
+++ b/internal/api/v0/endpoints/runtime/routes.go
@@ -1,6 +1,8 @@
 package runtime
 
 import (
+	"strings"
+
 	"github.com/gin-gonic/gin"
 
 	runtimehandlers "github.com/rabbytesoftware/quiver.core/internal/api/v0/endpoints/runtime/handlers"
@@ -14,6 +16,17 @@ func Register(
 ) {
 	h := runtimehandlers.New(svc)
 	rg.POST("/runtime/:ns/:method", h.Execute)
-	rg.GET("/runtime", runtimeWS)
-	rg.GET("/runtime/:ns", runtimeWS)
+	rg.GET("/runtime", dispatch(h.List, runtimeWS))
+	rg.GET("/runtime/:ns", dispatch(h.Get, runtimeWS))
+}
+
+// dispatch checks the Upgrade header. WS requests go to wsHandler; plain HTTP goes to rest.
+func dispatch(rest, ws gin.HandlerFunc) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if strings.EqualFold(c.GetHeader("Upgrade"), "websocket") {
+			ws(c)
+			return
+		}
+		rest(c)
+	}
 }

--- a/internal/api/v0/endpoints/runtime/routes_test.go
+++ b/internal/api/v0/endpoints/runtime/routes_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/rabbytesoftware/quiver.core/internal/api/mocks"
+	"github.com/rabbytesoftware/quiver.core/internal/domain"
+	domainRuntime "github.com/rabbytesoftware/quiver.core/internal/domain/runtime"
 )
 
 func stubWS(c *gin.Context) { c.Status(http.StatusOK) }
@@ -18,7 +20,13 @@ func TestRegister_MountsAllRoutes(t *testing.T) {
 	r := gin.New()
 	r.UseRawPath = true
 	r.UnescapePathValues = true
-	Register(r.Group(""), &mocks.RuntimeService{}, stubWS)
+	svc := &mocks.RuntimeService{
+		GetRuntimeResult: &domainRuntime.ArrowRuntime{
+			Ref:   "github.com/user/repo",
+			State: domain.ArrowStateReady,
+		},
+	}
+	Register(r.Group(""), svc, stubWS)
 
 	routes := []struct {
 		method string
@@ -35,4 +43,56 @@ func TestRegister_MountsAllRoutes(t *testing.T) {
 		r.ServeHTTP(w, req)
 		assert.NotEqual(t, http.StatusNotFound, w.Code, "%s %s should not 404", tc.method, tc.path)
 	}
+}
+
+func TestRegister_GetWithoutUpgradeServesREST(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.UseRawPath = true
+	r.UnescapePathValues = true
+	Register(r.Group(""), &mocks.RuntimeService{}, stubWS)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/runtime", nil))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"success":true`)
+}
+
+func TestRegister_GetNsWithoutUpgradeServesREST(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.UseRawPath = true
+	r.UnescapePathValues = true
+	svc := &mocks.RuntimeService{
+		GetRuntimeResult: &domainRuntime.ArrowRuntime{
+			Ref:   "github.com/user/repo",
+			State: domain.ArrowStateReady,
+		},
+	}
+	Register(r.Group(""), svc, stubWS)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/runtime/github.com%2Fuser%2Frepo", nil))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"state":"ready"`)
+}
+
+func TestRegister_GetWithUpgradeServesWS(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.UseRawPath = true
+	r.UnescapePathValues = true
+	Register(r.Group(""), &mocks.RuntimeService{}, func(c *gin.Context) {
+		c.String(http.StatusTeapot, "ws-handler")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/runtime", nil)
+	req.Header.Set("Upgrade", "websocket")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusTeapot, w.Code)
+	assert.Equal(t, "ws-handler", w.Body.String())
 }

--- a/internal/app/usecases/runtime.go
+++ b/internal/app/usecases/runtime.go
@@ -39,6 +39,13 @@ type RuntimeUsecase interface {
 		ctx context.Context,
 		ns domain.Namespace,
 	) (bool, error)
+	GetRuntime(
+		ctx context.Context,
+		ns domain.Namespace,
+	) (*domainRuntime.ArrowRuntime, error)
+	ListRuntimes(
+		ctx context.Context,
+	) ([]domainRuntime.ArrowRuntime, error)
 	Start(ctx context.Context)
 	Shutdown(ctx context.Context) error
 }
@@ -323,6 +330,52 @@ func (u *runtimeUsecase) RuntimeExists(
 	ns domain.Namespace,
 ) (bool, error) {
 	return u.runtime.RuntimeExists(ctx, ns)
+}
+
+func (u *runtimeUsecase) GetRuntime(
+	ctx context.Context,
+	ns domain.Namespace,
+) (*domainRuntime.ArrowRuntime, error) {
+	rt, err := u.runtime.GetRuntime(ctx, ns)
+	if err != nil {
+		return nil, fmt.Errorf("get runtime %s: %w", ns, err)
+	}
+	if rt != nil {
+		return rt, nil
+	}
+
+	exists, err := u.arrow.Exists(ctx, ns)
+	if err != nil {
+		return nil, fmt.Errorf("get runtime: check arrow %s: %w", ns, err)
+	}
+	if !exists {
+		return nil, fmt.Errorf("get runtime %s: %w", ns, apperrors.ErrNotFound)
+	}
+
+	return &domainRuntime.ArrowRuntime{Ref: ns, State: domain.ArrowStateAbsent}, nil
+}
+
+func (u *runtimeUsecase) ListRuntimes(
+	ctx context.Context,
+) ([]domainRuntime.ArrowRuntime, error) {
+	views, err := u.arrow.List(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list runtimes: list arrows: %w", err)
+	}
+
+	runtimes := make([]domainRuntime.ArrowRuntime, 0, len(views))
+	for _, v := range views {
+		rt, err := u.runtime.GetRuntime(ctx, v.Namespace)
+		if err != nil {
+			return nil, fmt.Errorf("list runtimes: get runtime %s: %w", v.Namespace, err)
+		}
+		if rt == nil {
+			rt = &domainRuntime.ArrowRuntime{Ref: v.Namespace, State: domain.ArrowStateAbsent}
+		}
+		runtimes = append(runtimes, *rt)
+	}
+
+	return runtimes, nil
 }
 
 func (u *runtimeUsecase) Start(ctx context.Context) {

--- a/internal/app/usecases/runtime_test.go
+++ b/internal/app/usecases/runtime_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	apperrors "github.com/rabbytesoftware/quiver.core/internal/app/errors"
+	"github.com/rabbytesoftware/quiver.core/internal/app/models"
 	"github.com/rabbytesoftware/quiver.core/internal/app/repositories/graph"
 	ucmocks "github.com/rabbytesoftware/quiver.core/internal/app/usecases/mocks"
 	"github.com/rabbytesoftware/quiver.core/internal/domain"
@@ -2062,5 +2063,176 @@ func TestRuntimeOnUninstallEnded_GetStateError_Skips(t *testing.T) {
 	})
 	if stopCalled {
 		t.Fatal("expected no Stop when GetState fails")
+	}
+}
+
+// ─── GetRuntime ──────────────────────────────────────────────────────────────
+
+func TestRuntimeGetRuntime_ReturnsAggregate(t *testing.T) {
+	want := domainRuntime.ArrowRuntime{Ref: "github.com/user/app@v1", State: domain.ArrowStateRunning}
+	rt := &ucmocks.MockRuntime{
+		GetRuntimeFn: func(_ context.Context, _ domain.Namespace) (*domainRuntime.ArrowRuntime, error) {
+			return &want, nil
+		},
+	}
+	uc := newUC(&ucmocks.MockArrow{}, rt, &ucmocks.MockGraph{})
+
+	got, err := uc.GetRuntime(context.Background(), "github.com/user/app@v1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Ref != want.Ref || got.State != want.State {
+		t.Fatalf("expected %+v, got %+v", want, got)
+	}
+}
+
+func TestRuntimeGetRuntime_SynthesizesAbsentWhenArrowExists(t *testing.T) {
+	rt := &ucmocks.MockRuntime{
+		GetRuntimeFn: func(_ context.Context, _ domain.Namespace) (*domainRuntime.ArrowRuntime, error) {
+			return nil, nil
+		},
+	}
+	a := &ucmocks.MockArrow{
+		ExistsFn: func(_ context.Context, _ domain.Namespace) (bool, error) { return true, nil },
+	}
+	uc := newUC(a, rt, &ucmocks.MockGraph{})
+
+	got, err := uc.GetRuntime(context.Background(), "github.com/user/app@v1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Ref != "github.com/user/app@v1" || got.State != domain.ArrowStateAbsent {
+		t.Fatalf("expected synthesized absent runtime, got %+v", got)
+	}
+}
+
+func TestRuntimeGetRuntime_NotFoundWhenArrowMissing(t *testing.T) {
+	rt := &ucmocks.MockRuntime{
+		GetRuntimeFn: func(_ context.Context, _ domain.Namespace) (*domainRuntime.ArrowRuntime, error) {
+			return nil, nil
+		},
+	}
+	a := &ucmocks.MockArrow{
+		ExistsFn: func(_ context.Context, _ domain.Namespace) (bool, error) { return false, nil },
+	}
+	uc := newUC(a, rt, &ucmocks.MockGraph{})
+
+	_, err := uc.GetRuntime(context.Background(), "github.com/user/app@v1")
+	if !errors.Is(err, apperrors.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestRuntimeGetRuntime_RepoErrorWrapped(t *testing.T) {
+	boom := errors.New("boom")
+	rt := &ucmocks.MockRuntime{
+		GetRuntimeFn: func(_ context.Context, _ domain.Namespace) (*domainRuntime.ArrowRuntime, error) {
+			return nil, boom
+		},
+	}
+	uc := newUC(&ucmocks.MockArrow{}, rt, &ucmocks.MockGraph{})
+
+	_, err := uc.GetRuntime(context.Background(), "github.com/user/app@v1")
+	if !errors.Is(err, boom) {
+		t.Fatalf("expected wrapped repo error, got %v", err)
+	}
+}
+
+func TestRuntimeGetRuntime_ExistsErrorWrapped(t *testing.T) {
+	boom := errors.New("exists failed")
+	rt := &ucmocks.MockRuntime{
+		GetRuntimeFn: func(_ context.Context, _ domain.Namespace) (*domainRuntime.ArrowRuntime, error) {
+			return nil, nil
+		},
+	}
+	a := &ucmocks.MockArrow{
+		ExistsFn: func(_ context.Context, _ domain.Namespace) (bool, error) { return false, boom },
+	}
+	uc := newUC(a, rt, &ucmocks.MockGraph{})
+
+	_, err := uc.GetRuntime(context.Background(), "github.com/user/app@v1")
+	if !errors.Is(err, boom) {
+		t.Fatalf("expected wrapped exists error, got %v", err)
+	}
+}
+
+// ─── ListRuntimes ────────────────────────────────────────────────────────────
+
+func TestRuntimeListRuntimes_MergesRuntimeState(t *testing.T) {
+	a := &ucmocks.MockArrow{
+		ListFn: func(_ context.Context, _ *bool) ([]models.ArrowView, error) {
+			return []models.ArrowView{
+				{Namespace: "github.com/user/running@v1"},
+				{Namespace: "github.com/user/fresh@v1"},
+			}, nil
+		},
+	}
+	rt := &ucmocks.MockRuntime{
+		GetRuntimeFn: func(_ context.Context, ns domain.Namespace) (*domainRuntime.ArrowRuntime, error) {
+			if ns == "github.com/user/running@v1" {
+				return &domainRuntime.ArrowRuntime{Ref: ns, State: domain.ArrowStateRunning}, nil
+			}
+			return nil, nil
+		},
+	}
+	uc := newUC(a, rt, &ucmocks.MockGraph{})
+
+	got, err := uc.ListRuntimes(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 runtimes, got %d", len(got))
+	}
+	if got[0].State != domain.ArrowStateRunning {
+		t.Fatalf("expected first runtime running, got %s", got[0].State)
+	}
+	if got[1].State != domain.ArrowStateAbsent || got[1].Ref != "github.com/user/fresh@v1" {
+		t.Fatalf("expected synthesized absent runtime for fresh arrow, got %+v", got[1])
+	}
+}
+
+func TestRuntimeListRuntimes_EmptyCatalog(t *testing.T) {
+	uc := newUC(&ucmocks.MockArrow{}, &ucmocks.MockRuntime{}, &ucmocks.MockGraph{})
+
+	got, err := uc.ListRuntimes(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty list, got %d", len(got))
+	}
+}
+
+func TestRuntimeListRuntimes_ListErrorWrapped(t *testing.T) {
+	boom := errors.New("list failed")
+	a := &ucmocks.MockArrow{
+		ListFn: func(_ context.Context, _ *bool) ([]models.ArrowView, error) { return nil, boom },
+	}
+	uc := newUC(a, &ucmocks.MockRuntime{}, &ucmocks.MockGraph{})
+
+	_, err := uc.ListRuntimes(context.Background())
+	if !errors.Is(err, boom) {
+		t.Fatalf("expected wrapped list error, got %v", err)
+	}
+}
+
+func TestRuntimeListRuntimes_GetRuntimeErrorWrapped(t *testing.T) {
+	boom := errors.New("get failed")
+	a := &ucmocks.MockArrow{
+		ListFn: func(_ context.Context, _ *bool) ([]models.ArrowView, error) {
+			return []models.ArrowView{{Namespace: "github.com/user/app@v1"}}, nil
+		},
+	}
+	rt := &ucmocks.MockRuntime{
+		GetRuntimeFn: func(_ context.Context, _ domain.Namespace) (*domainRuntime.ArrowRuntime, error) {
+			return nil, boom
+		},
+	}
+	uc := newUC(a, rt, &ucmocks.MockGraph{})
+
+	_, err := uc.ListRuntimes(context.Background())
+	if !errors.Is(err, boom) {
+		t.Fatalf("expected wrapped get error, got %v", err)
 	}
 }


### PR DESCRIPTION
## Description
Runtime routes (`GET /v0/runtime`, `GET /v0/runtime/:ns`) were bound directly to the WebSocket broadcaster — a plain GET hit the upgrader and returned 400. This made the documented WS reconciliation model ("fetch current state via REST, then subscribe for updates") impossible for the runtime channel, and left clients no way to read execution state (active run, PID, step progress, last return) on demand.

This PR brings runtime routes to parity with arrow and collection routes: the same `dispatch(rest, ws)` helper now routes plain GETs to REST handlers while WebSocket upgrades keep flowing to the broadcaster. Groundwork for the Quiver CLI (`quiver ps`, `quiver status`).

## Type of Change
- [x] ✨ New feature (feature/*)

## Related Issues
Groundwork for the CLI (see docs PR #193).

## Changes Made
- `RuntimeUsecase.GetRuntime(ns)` — returns the runtime aggregate; synthesizes `absent` for catalog arrows never installed; `ErrNotFound` for unknown namespaces
- `RuntimeUsecase.ListRuntimes()` — one runtime snapshot per catalog arrow
- REST handlers `Get` / `List` on the runtime endpoint group, reusing `ArrowRuntimeDTO`
- Runtime routes wrapped in `dispatch(rest, ws)` — WS behaviour unchanged
- Extended `api/mocks.RuntimeService`; swagger regenerated

## Breaking Changes
- [ ] This PR introduces breaking changes
- [ ] Migration guide provided (if yes)

## Checklist
- [x] Code follows Clean Architecture principles
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic
- [x] All documentation updated in `./docs/` folder
- [x] **🚨 Tests pass locally (`make test`)**
- [x] Coverage requirements met (`make test-coverage`) — usecases 95.3%, routes 100%, handlers 97.4%
- [x] No linting errors (`make lint`)
- [ ] Security scan passes (`make security`) — not run locally; no new I/O paths
- [x] Branch name follows convention (enhancement/*, feature/*, fix/*, hotfix/*, release/*)

🤖 Generated with [Claude Code](https://claude.com/claude-code)