### PR TITLE
fix(api): allow bare-namespace arrow DELETE

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -173,7 +173,7 @@ const docTemplate = `{
                 }
             },
             "delete": {
-                "description": "Deregisters an arrow. The namespace must include a @ref (version) qualifier.",
+                "description": "Deregisters an arrow. The namespace must match the one the arrow was registered under, including its @ref qualifier when present.",
                 "tags": [
                     "arrows"
                 ],
@@ -181,7 +181,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Versioned arrow namespace (e.g. github.com/user/repo@v1.0.0)",
+                        "description": "Arrow namespace as registered (e.g. github.com/user/repo@v1.0.0)",
                         "name": "ns",
                         "in": "path",
                         "required": true
@@ -192,12 +192,6 @@ const docTemplate = `{
                         "description": "Arrow removed",
                         "schema": {
                             "$ref": "#/definitions/github_com_rabbytesoftware_quiver_core_internal_api_libs.MutationResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Namespace missing @ref",
-                        "schema": {
-                            "$ref": "#/definitions/github_com_rabbytesoftware_quiver_core_internal_api_libs.ErrResponse"
                         }
                     },
                     "404": {

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -167,7 +167,7 @@
                 }
             },
             "delete": {
-                "description": "Deregisters an arrow. The namespace must include a @ref (version) qualifier.",
+                "description": "Deregisters an arrow. The namespace must match the one the arrow was registered under, including its @ref qualifier when present.",
                 "tags": [
                     "arrows"
                 ],
@@ -175,7 +175,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Versioned arrow namespace (e.g. github.com/user/repo@v1.0.0)",
+                        "description": "Arrow namespace as registered (e.g. github.com/user/repo@v1.0.0)",
                         "name": "ns",
                         "in": "path",
                         "required": true
@@ -186,12 +186,6 @@
                         "description": "Arrow removed",
                         "schema": {
                             "$ref": "#/definitions/github_com_rabbytesoftware_quiver_core_internal_api_libs.MutationResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Namespace missing @ref",
-                        "schema": {
-                            "$ref": "#/definitions/github_com_rabbytesoftware_quiver_core_internal_api_libs.ErrResponse"
                         }
                     },
                     "404": {

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -521,10 +521,10 @@ paths:
       - arrows
   /arrow/{ns}:
     delete:
-      description: Deregisters an arrow. The namespace must include a @ref (version)
-        qualifier.
+      description: Deregisters an arrow. The namespace must match the one the arrow
+        was registered under, including its @ref qualifier when present.
       parameters:
-      - description: Versioned arrow namespace (e.g. github.com/user/repo@v1.0.0)
+      - description: Arrow namespace as registered (e.g. github.com/user/repo@v1.0.0)
         in: path
         name: ns
         required: true
@@ -534,10 +534,6 @@ paths:
           description: Arrow removed
           schema:
             $ref: '#/definitions/github_com_rabbytesoftware_quiver_core_internal_api_libs.MutationResponse'
-        "400":
-          description: Namespace missing @ref
-          schema:
-            $ref: '#/definitions/github_com_rabbytesoftware_quiver_core_internal_api_libs.ErrResponse'
         "404":
           description: Arrow not found
           schema:

--- a/internal/api/v0/endpoints/arrows/handlers/handlers.go
+++ b/internal/api/v0/endpoints/arrows/handlers/handlers.go
@@ -69,23 +69,18 @@ func (h *Handlers) Update(c *gin.Context) {
 	libs.WriteMutationOK(c, http.StatusOK, string(ns))
 }
 
-// Remove deregisters a specific versioned arrow.
+// Remove deregisters an arrow.
 //
 // @Summary      Remove arrow
-// @Description  Deregisters an arrow. The namespace must include a @ref (version) qualifier.
+// @Description  Deregisters an arrow. The namespace must match the one the arrow was registered under, including its @ref qualifier when present.
 // @Tags         arrows
-// @Param        ns   path  string  true  "Versioned arrow namespace (e.g. github.com/user/repo@v1.0.0)"
+// @Param        ns   path  string  true  "Arrow namespace as registered (e.g. github.com/user/repo@v1.0.0)"
 // @Success      200  {object}  libs.MutationResponse  "Arrow removed"
-// @Failure      400  {object}  libs.ErrResponse       "Namespace missing @ref"
 // @Failure      404  {object}  libs.ErrResponse       "Arrow not found"
 // @Failure      500  {object}  libs.ErrResponse       "Internal error"
 // @Router       /arrow/{ns} [delete]
 func (h *Handlers) Remove(c *gin.Context) {
 	ns := domain.Namespace(c.Param("ns"))
-	if ns.Ref() == "" {
-		libs.WriteErr(c, http.StatusBadRequest, "namespace must be versioned (include @ref) for DELETE", string(ns))
-		return
-	}
 	if err := h.svc.Remove(c.Request.Context(), ns); err != nil {
 		status, msg := apierr.StatusAndMessage(err)
 		libs.WriteErr(c, status, msg, string(ns))

--- a/internal/api/v0/endpoints/arrows/handlers/handlers_test.go
+++ b/internal/api/v0/endpoints/arrows/handlers/handlers_test.go
@@ -84,12 +84,20 @@ func TestRemove_OK(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
-func TestRemove_BareNamespace_ReturnsBadRequest(t *testing.T) {
+func TestRemove_BareNamespace_ReachesService(t *testing.T) {
 	svc := &mocks.ArrowService{}
 	_, r := setup(svc)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, encodedNS, nil))
-	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestRemove_BareNamespace_UnknownReturnsNotFound(t *testing.T) {
+	svc := &mocks.ArrowService{RemoveErr: apperrors.ErrNotFound}
+	_, r := setup(svc)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodDelete, encodedNS, nil))
+	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 func TestRemove_DependentsExist(t *testing.T) {


### PR DESCRIPTION
## Description
Arrows registered via `arrow add` with a plain bare namespace are stored under an aggregate ID **without** a ref (`ResolveForInstall` only resolves refs for glob namespaces). The DELETE handler required `@ref`, so those arrows could never be removed through the API — reproduced in the field with `github.com/Valentin-Vi/quiver.arrow-discord`, whose event-store aggregate ID is the bare namespace while `DELETE /v0/arrow/:ns` rejected both the bare form (400) and any versioned guess (404).

This drops the `@ref` guard: removal targets the exact namespace the arrow was registered under, and the repository's exact-match lookup answers 404 for unknown namespaces. Versioned aggregates are unaffected.

## Type of Change
- [x] 🐛 Bug fix (fix/*)

## Related Issues
N/A (found during CLI verification, see #195)

## Changes Made
- `internal/api/v0/endpoints/arrows/handlers/handlers.go` — remove the ref-required guard on `Remove`; update swagger annotations
- `internal/api/v0/endpoints/arrows/handlers/handlers_test.go` — bare-namespace DELETE now reaches the service (200) and unknown namespaces map to 404
- `docs/swagger/` — regenerated

## Breaking Changes
- [ ] This PR introduces breaking changes
- [ ] Migration guide provided (if yes)

## Checklist
- [x] Code follows Clean Architecture principles
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic
- [x] All documentation updated in `./docs/` folder
- [x] **🚨 Tests pass locally (`make test`)**
- [x] Coverage requirements met (`make test-coverage`)
- [x] No linting errors (`make lint`)
- [x] Security scan passes (`make security`)
- [x] Branch name follows convention (enhancement/*, feature/*, fix/*, hotfix/*, release/*)

🤖 Generated with [Claude Code](https://claude.com/claude-code)