### PR TITLE
Add self-update bootstrap foundations

### DIFF
--- a/cmd/quiver/daemon.go
+++ b/cmd/quiver/daemon.go
@@ -2,13 +2,16 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"os"
 	"os/signal"
 	"syscall"
 
 	"github.com/spf13/cobra"
 
 	"github.com/rabbytesoftware/quiver.core/internal"
+	"github.com/rabbytesoftware/quiver.core/internal/core/build"
 )
 
 func newDaemonCmd() *cobra.Command {
@@ -21,7 +24,12 @@ func newDaemonCmd() *cobra.Command {
 			ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 			defer stop()
 
-			container, err := internal.New(ctx, version, buildID)
+			buildInfo, err := resolveBuildInfo(ctx)
+			if err != nil {
+				return err
+			}
+
+			container, err := internal.New(ctx, buildInfo)
 			if err != nil {
 				return err
 			}
@@ -35,6 +43,33 @@ func newDaemonCmd() *cobra.Command {
   unix:///custom/path/quiver.sock   Unix domain socket at custom path
   unix://                           Unix domain socket at default path (~/.quiver/quiver.sock)
   tcp://0.0.0.0:40257               TCP socket (remote mode)`)
-
 	return cmd
+}
+
+const updateAttemptTokenEnv = "QUIVER_UPDATE_ATTEMPT_TOKEN"
+
+func resolveBuildInfo(ctx context.Context) (build.Info, error) {
+	return resolveBuildInfoWith(ctx, os.Getenv(updateAttemptTokenEnv), os.Executable, build.Digest)
+}
+
+func resolveBuildInfoWith(
+	ctx context.Context,
+	attemptToken string,
+	executable func() (string, error),
+	digest func(context.Context, string) (string, error),
+) (build.Info, error) {
+	path, err := executable()
+	if err != nil {
+		return build.Info{}, fmt.Errorf("daemon: resolve executable: %w", err)
+	}
+	sha256, err := digest(ctx, path)
+	if err != nil {
+		return build.Info{}, fmt.Errorf("daemon: %w", err)
+	}
+	return build.Info{
+		Version:      version,
+		BuildID:      buildID,
+		Digest:       sha256,
+		AttemptToken: attemptToken,
+	}, nil
 }

--- a/cmd/quiver/main_test.go
+++ b/cmd/quiver/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,4 +26,64 @@ func TestDaemonCommand_HostFlag_AcceptsURIFormats(t *testing.T) {
 	flag := cmd.Flags().Lookup("host")
 	assert.NotNil(t, flag)
 	assert.Equal(t, "", flag.DefValue)
+}
+
+func TestDaemonCommand_DoesNotExposeUpdateAttemptTokenFlag(t *testing.T) {
+	cmd := newDaemonCmd()
+	assert.Nil(t, cmd.Flags().Lookup("update-attempt-token"))
+}
+
+func TestResolveBuildInfoWith_ValidExecutableReturnsIdentity(t *testing.T) {
+	info, err := resolveBuildInfoWith(
+		context.Background(),
+		"attempt",
+		func() (string, error) { return "/bin/quiver", nil },
+		func(_ context.Context, path string) (string, error) {
+			assert.Equal(t, "/bin/quiver", path)
+			return "digest", nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, version, info.Version)
+	assert.Equal(t, buildID, info.BuildID)
+	assert.Equal(t, "digest", info.Digest)
+	assert.Equal(t, "attempt", info.AttemptToken)
+}
+
+func TestResolveBuildInfo_RunningTestBinaryReturnsDigest(t *testing.T) {
+	t.Setenv(updateAttemptTokenEnv, "attempt")
+	info, err := resolveBuildInfo(context.Background())
+
+	require.NoError(t, err)
+	assert.Len(t, info.Digest, 64)
+	assert.Equal(t, "attempt", info.AttemptToken)
+}
+
+func TestResolveBuildInfoWith_ExecutableFailureReturnsError(t *testing.T) {
+	wantErr := errors.New("executable failed")
+
+	info, err := resolveBuildInfoWith(
+		context.Background(),
+		"attempt",
+		func() (string, error) { return "", wantErr },
+		func(context.Context, string) (string, error) { return "", nil },
+	)
+
+	require.ErrorIs(t, err, wantErr)
+	assert.Empty(t, info)
+}
+
+func TestResolveBuildInfoWith_DigestFailureReturnsError(t *testing.T) {
+	wantErr := errors.New("digest failed")
+
+	info, err := resolveBuildInfoWith(
+		context.Background(),
+		"attempt",
+		func() (string, error) { return "/bin/quiver", nil },
+		func(context.Context, string) (string, error) { return "", wantErr },
+	)
+
+	require.ErrorIs(t, err, wantErr)
+	assert.Empty(t, info)
 }

--- a/docs/proposals/self-update-versioned-bootstrap.md
+++ b/docs/proposals/self-update-versioned-bootstrap.md
@@ -1,0 +1,393 @@
+# Quiver Self-Update — Iteración 3: bootstrap e instalaciones versionadas
+
+**Estado:** Propuesta revisada según devolución del team
+
+**Issue:** [#163 — Quiver managing itself](https://github.com/rabbytesoftware/quiver.core/issues/163)
+
+**Target:** `develop`
+
+## 1. Veredicto
+
+El enfoque es válido y es la opción recomendada para continuar.
+
+La mejora central consiste en no sobrescribir el binario funcional para probar un candidato. Cada release se guarda en un directorio inmutable y versionado; el bootstrap inicia el candidato desde allí y solamente actualiza el puntero `current` después de verificar que el nuevo daemon levantó correctamente.
+
+Esto convierte el rollback en una selección de versión, no en una reparación de archivos:
+
+```text
+direct replacement:
+backup -> replace -> test -> restore on failure
+
+versioned activation:
+start candidate -> test -> promote pointer on success
+                         -> keep previous pointer on failure
+```
+
+La propuesta introduce de manera explícita un bootstrap estable. Funcionalmente cumple el rol de un launcher, pero sigue siendo parte de Quiver: no es un package manager, una aplicación adicional ni un servicio de terceros.
+
+## 2. Respuesta a la propuesta del team
+
+El flujo propuesto es correcto con dos ajustes:
+
+1. El bootstrap no debería terminar inmediatamente después del health check si desktop, systemd o algún otro supervisor está siguiendo su PID. Para el MVP puede permanecer como padre del daemon, reenviar señales y esperar su finalización.
+2. Las versiones pueden vivir físicamente en el workdir de la Arrow de Quiver, pero ese subárbol debe tener ownership explícito del updater y quedar protegido de `DeleteWorkDir`.
+
+El resto del razonamiento se mantiene:
+
+- El bootstrap corre antes de `internal.New`.
+- El daemon anterior ya terminó y el bootstrap no ocupa el socket.
+- El candidato abre los stores y ocupa el socket normal.
+- Un probe correlacionado valida exactamente ese intento.
+- El candidato solamente se vuelve `current` después de responder correctamente.
+- La versión anterior permanece intacta y lista para rollback.
+
+## 3. Layout propuesto
+
+Tomando como namespace de sistema el indicado por el team:
+
+```text
+github.com/rabbytesoftware/quiver
+```
+
+el layout puede vivir en su workdir:
+
+```text
+~/.quiver/namespaces/github.com/rabbytesoftware/quiver/
+├── versions/
+│   ├── 25.9.0-4b2c.../
+│   │   ├── quiver
+│   │   └── artifact.json
+│   └── 25.9.1-980a.../
+│       ├── quiver
+│       └── artifact.json
+└── update/
+    ├── current.json
+    ├── staged.json
+    ├── attempt.json
+    └── history.jsonl
+```
+
+En Windows el ejecutable sería `quiver.exe`.
+
+Propiedades del layout:
+
+- `<version>-<digest>` hace que cada instalación sea inmutable y content-addressed.
+- `current.json` selecciona la versión activa y conserva la selección anterior.
+- `staged.json` describe un candidato descargado y verificado.
+- `attempt.json` permite recuperar una activación interrumpida.
+- El historial es diagnóstico; no es la fuente de verdad para arrancar.
+- Todos los paths almacenados deben ser relativos al workdir y validados contra path traversal.
+
+El namespace debe confirmarse como decisión definitiva porque los documentos anteriores usaban `github.com/rabbytesoftware/quiver.core`.
+
+## 4. Compatibilidad con Vault
+
+El código actual permite usar ese workdir, pero requiere una protección adicional:
+
+- `Vault.WorkDir` crea un path durable bajo `~/.quiver/namespaces/<namespace>`.
+- El sweep de TTL elimina manifests y metadata vencida; no elimina el workdir.
+- `Vault.DeleteWorkDir` sí ejecuta `os.RemoveAll` sobre todo el workdir.
+- El repositorio de Arrows llama `DeleteWorkDir` cuando una Arrow es olvidada.
+
+Por lo tanto, no alcanza con asumir que la Arrow built-in nunca será removida desde la UI. Debe existir una garantía de sistema:
+
+- La Arrow de Quiver no puede ser olvidada, removida ni desinstalada mediante operaciones comunes.
+- El cleanup genérico de Vault no puede alcanzar `versions/` mientras haya una versión referenciada.
+- El updater es el único dueño de la retención dentro de `versions/` y `update/`.
+
+El bootstrap corre antes de construir Vault. No debería abrir el índice de Vault solamente para resolver el path. Conviene agregar un resolver determinístico de path en `internal/core/paths` y hacer que Vault y bootstrap compartan esa única función.
+
+## 5. Flujo de primera migración
+
+En el primer arranque con soporte de auto-update todavía existe un único binario instalado fuera de `versions/`.
+
+El bootstrap debe crear una base conocida para rollback:
+
+1. Obtener el ejecutable actual mediante `os.Executable()`.
+2. Calcular su digest real.
+3. Crear `versions/<current-version>-<digest>/`.
+4. Copiar allí el binario actual sin modificar el original.
+5. Verificar que la copia produzca el mismo digest.
+6. Crear `current.json` apuntando a esa versión.
+7. Continuar con la evaluación del candidato.
+
+Esta operación es idempotente: si el directorio y la metadata coinciden, no vuelve a copiar.
+
+## 6. Flujo de activación
+
+```mermaid
+flowchart TD
+    Entry["Stable Quiver bootstrap"]
+    State["Read current and staged state"]
+    Baseline["Ensure current binary is versioned"]
+    Token["Create random attempt token"]
+    Candidate["Start candidate from versions directory"]
+    Ping["Probe stable /ping contract"]
+    Promote["Atomically promote current pointer"]
+    Supervise["Forward signals and supervise active daemon"]
+    Stop["Stop failed candidate"]
+    Previous["Start previous current version"]
+    Record["Record rollback or failure"]
+
+    Entry --> State
+    State -->|staged candidate| Baseline
+    Baseline --> Token
+    Token --> Candidate
+    Candidate --> Ping
+    Ping -->|matching response| Promote
+    Promote --> Supervise
+    Ping -->|error or timeout| Stop
+    Stop --> Previous
+    Previous --> Record
+    Record --> Supervise
+```
+
+Pasos detallados:
+
+1. El entrypoint estable comienza antes de `internal.New`.
+2. Adquiere un lock exclusivo de bootstrap/update.
+3. Lee y valida `current.json`, `staged.json` y cualquier intento interrumpido.
+4. Garantiza que la versión actual exista dentro de `versions/`.
+5. Genera un token aleatorio para este intento.
+6. Inicia el candidato desde su directorio versionado.
+7. El candidato ejecuta su arranque normal, incluyendo `internal.New`, recuperación y bind del socket.
+8. El bootstrap consulta `/ping` hasta alcanzar un timeout.
+9. Si versión, digest y token coinciden, promueve el candidato mediante `current.json`.
+10. Si falla, termina el candidato, conserva el puntero anterior e inicia la versión previa.
+11. Registra el resultado y conserva la evidencia necesaria para diagnóstico.
+
+## 7. Contrato estable de readiness
+
+Actualmente Quiver expone:
+
+```text
+GET /v0/health -> {"status":"ok"}
+GET /versions  -> version + build_id + API versions
+```
+
+Ninguno identifica un intento de actualización concreto. Se propone agregar un endpoint mínimo y no versionado porque debe mantenerse compatible con bootstraps anteriores:
+
+```text
+GET /ping
+```
+
+Respuesta durante un intento:
+
+```json
+{
+  "success": true,
+  "data": {
+    "status": "ready",
+    "version": "25.9.1",
+    "build_id": "123",
+    "digest": "980a...",
+    "attempt_token": "random-per-attempt-value"
+  }
+}
+```
+
+El token se genera localmente y se pasa al candidato mediante una variable de entorno reservada, nunca como argumento visible en el listado de procesos. No concede permisos: solamente evita confundir la respuesta del candidato con otro daemon que ya estuviera escuchando.
+
+El endpoint es válido como señal de readiness porque el listener actual se crea después de:
+
+- Construir engines, adapters, app y API en `internal.New`.
+- Abrir event stores, snapshots y read models.
+- Ejecutar la recuperación síncrona de runtimes mediante `App.Start`.
+- Crear y servir el listener.
+
+El bootstrap debe comparar los cuatro valores esperados. Un `200 OK` sin identidad coincidente no promueve el candidato.
+
+## 8. Puntero `current`
+
+El puntero no debe ser un path remoto ni una cadena libre. Debe guardar identidad verificable:
+
+```json
+{
+  "schema": 1,
+  "generation": 4,
+  "current": {
+    "version": "25.9.1",
+    "digest": "980a...",
+    "executable": "versions/25.9.1-980a.../quiver"
+  },
+  "previous": {
+    "version": "25.9.0",
+    "digest": "4b2c...",
+    "executable": "versions/25.9.0-4b2c.../quiver"
+  },
+  "promoted_at": "2026-08-14T00:00:00Z"
+}
+```
+
+Reglas:
+
+- El path debe ser relativo y quedar contenido en el workdir de sistema.
+- El digest del archivo debe verificarse antes de cada promoción.
+- La escritura debe usar archivo temporal, flush y reemplazo atómico.
+- La implementación de reemplazo atómico necesita archivos específicos por plataforma.
+- Un pointer corrupto no puede causar la ejecución de un path arbitrario.
+- `current` y `previous` deben cambiar en una sola escritura del pointer para no quedar desincronizados.
+
+Una alternativa futura es usar dos slots de puntero con contador de generación. Eso evita depender de que todas las plataformas tengan exactamente la misma semántica de replace sobre un archivo existente.
+
+## 9. Ownership del proceso
+
+Este punto modifica el paso “marca al candidato como actual y termina”.
+
+Si el bootstrap fue iniciado por desktop, systemd, launchd o Windows Service Manager, terminar puede hacer que el supervisor:
+
+- Interprete que Quiver terminó.
+- Mate también al proceso hijo.
+- Inicie una segunda copia.
+- Pierda la capacidad de enviar señales al daemon real.
+
+Para un MVP uniforme se recomienda:
+
+```text
+external owner -> stable bootstrap -> active versioned daemon
+```
+
+El bootstrap permanece durante la sesión y:
+
+- No abre el socket de Quiver.
+- Reenvía SIGINT/SIGTERM o el mecanismo equivalente.
+- Espera la salida del daemon hijo.
+- Devuelve un exit code coherente al owner externo.
+- Puede aplicar el rollback si el candidato falla durante la ventana de validación.
+
+Esto convierte al bootstrap en un supervisor mínimo y estable. Si el proyecto no acepta un proceso padre permanente, será necesario definir un protocolo específico con la aplicación desktop y backends diferentes para service managers.
+
+En Unix puede evaluarse `exec` para reemplazar el proceso conservando el PID una vez elegida la versión. Windows no ofrece la misma semántica, por lo que no resuelve por sí solo el objetivo multiplataforma.
+
+## 10. Arranques posteriores
+
+Una vez promovido un candidato, el ejecutable público estable continúa siendo el punto de entrada:
+
+```text
+user/service starts quiver
+  -> bootstrap reads current.json
+  -> bootstrap validates selected binary
+  -> bootstrap starts versions/<current>/quiver
+  -> bootstrap validates /ping for the selected binary
+  -> versioned daemon skips bootstrap recursion
+```
+
+El child debe recibir una marca interna que indique que ya fue seleccionado por el bootstrap. De lo contrario, cada binario versionado volvería a leer `current` y se produciría recursión.
+
+El bootstrap debería validar el daemon seleccionado en cada arranque, no solamente durante una promoción. Si `current` deja de iniciar en un arranque futuro, puede intentar `previous`, verificarlo y actualizar la selección. Esto cubre fallos que aparezcan después de la primera ventana de promoción.
+
+El formato de `current.json` debe ser deliberadamente estable. Un bootstrap antiguo seguirá siendo el entrypoint en futuros releases. Actualizar el propio bootstrap puede diseñarse después y no debe formar parte del primer MVP.
+
+## 11. Rollback
+
+El rollback ya no necesita restaurar archivos:
+
+1. No promover `current` si el candidato falla.
+2. Terminar el candidato y esperar su salida.
+3. Iniciar la versión todavía seleccionada por `current.json`.
+4. Verificar su `/ping` con un nuevo token de intento.
+5. Registrar resultado, versión, digest, etapa y error.
+
+Si una versión que ya había sido promovida falla en un arranque posterior, el bootstrap usa el campo `previous` del mismo pointer, lo verifica y solamente entonces invierte la selección.
+
+Se deben conservar como mínimo:
+
+- La versión `current`.
+- La versión anterior a `current`.
+- El candidato `staged`, mientras el intento sea recuperable.
+
+El garbage collector solamente puede borrar versiones que no estén referenciadas por `current`, `staged`, un intento activo o la política de previous-version retention.
+
+## 12. Compatibilidad de datos
+
+El nuevo layout reduce el riesgo sobre ejecutables, pero no sobre datos.
+
+El candidato abre SQLite, event stores, snapshots y configuración antes de responder `/ping`. Si ejecuta una migración incompatible, iniciar la versión anterior puede fallar aunque su binario siga intacto.
+
+Para el MVP:
+
+- Los releases automáticos deben mantener compatibilidad hacia atrás.
+- No deben existir migraciones destructivas antes de readiness.
+- Los cambios de schema deben ser aditivos o reversibles.
+- La metadata firmada debe declarar la versión mínima de datos.
+- Un candidato incompatible debe rechazarse antes de ejecutarlo.
+
+Las migraciones irreversibles requieren otro flujo y quedan fuera del auto-update automático.
+
+## 13. Estados mínimos
+
+```text
+idle
+checking
+downloading
+verified
+staged
+probing
+promoted
+rollback_starting
+rolled_back
+failed
+```
+
+`current.json` es la fuente de verdad de selección. `attempt.json` describe una transición; no debe poder contradecir silenciosamente al pointer.
+
+## 14. Seguridad
+
+- Verificar firma de metadata antes de descargar.
+- Verificar tamaño y digest antes de mover a `versions/`.
+- Hacer inmutables los directorios versionados desde la perspectiva del updater.
+- Rechazar downgrades salvo rollback local explícito.
+- Validar que todos los paths permanezcan dentro del workdir reservado.
+- Usar permisos exclusivos del usuario de Quiver.
+- Mantener un único lock de bootstrap/update.
+- No aceptar versión, digest, token ni executable path desde requests externas.
+- No promover un candidato que responda con un token distinto.
+- No abrir, crear ni ejecutar artefactos a partir de un path previamente validado. Esas operaciones deben encapsularse por plataforma mediante handles o `dirfd` con semántica no-follow, evitando ventanas TOCTOU.
+- No borrar la versión anterior hasta confirmar una política de retención segura.
+
+## 15. Alcance recomendado del primer código
+
+La arquitectura ya está suficientemente definida para comenzar por un spike, no todavía por todo el updater end-to-end.
+
+Primer corte recomendado:
+
+1. Resolver el layout de versiones dentro del workdir protegido.
+2. Modelar y validar `current.json`, `staged.json` y `attempt.json`.
+3. Implementar escrituras atómicas por plataforma con tests de fallo.
+4. Agregar el `/ping` estable con versión, digest y token.
+5. Implementar un bootstrap de prueba que inicie un candidato fixture.
+6. Probar success, timeout, wrong token, wrong digest, crash y rollback.
+7. Validar process ownership en Linux, macOS y Windows antes de integrar descarga real.
+
+La integración con Manifold, Vault y releases puede construirse después de comprobar que el bootstrap y el ownership funcionan en las tres familias de sistema operativo.
+
+## 16. Decisiones pendientes
+
+- [ ] Confirmar `github.com/rabbytesoftware/quiver` como namespace built-in definitivo.
+- [ ] Aceptar que el entrypoint estable funciona como bootstrap/launcher de Quiver.
+- [ ] Decidir si el bootstrap permanece como supervisor durante toda la sesión.
+- [ ] Definir el contrato con la aplicación desktop y service managers.
+- [ ] Proteger `versions/` y `update/` de `DeleteWorkDir`.
+- [ ] Definir el mecanismo atómico de `current` en Windows.
+- [ ] Seleccionar Ed25519 o Sigstore para la metadata de release.
+- [ ] Definir timeout y criterio exacto de readiness.
+- [ ] Definir retención de versiones y límite de disco.
+- [ ] Excluir formalmente migraciones irreversibles del auto-update.
+
+## 17. Criterios de aceptación
+
+1. El entrypoint puede seleccionar una versión sin ejecutar `internal.New` en el bootstrap.
+2. La versión vigente queda copiada y verificada en su directorio content-addressed.
+3. El candidato se ejecuta sin modificar la versión vigente.
+4. Solamente el candidato correcto puede satisfacer el probe de readiness.
+5. `current` cambia únicamente después de un probe exitoso.
+6. Un timeout o crash conserva el pointer anterior.
+7. El bootstrap puede iniciar y verificar la versión anterior después del fallo.
+8. Un intento interrumpido se reconcilia de manera determinística al próximo arranque.
+9. Ningún cleanup genérico elimina una versión referenciada.
+10. El owner externo observa un único lifecycle coherente del daemon.
+11. El comportamiento está probado en Linux, macOS y Windows AMD64.
+
+## 18. Respuesta corta para el team
+
+> Sí, es válido y me parece mejor que reemplazar el ejecutable directamente. Guardar releases inmutables en `versions/<version>-<digest>`, probar el candidato y recién después mover `current` hace que el rollback sea selección de versión y no reparación de archivos. El workdir de la Arrow built-in sirve físicamente: el sweep de Vault no lo borra, aunque tenemos que proteger `versions/` del `DeleteWorkDir` que se ejecuta al olvidar una Arrow. Haría dos ajustes al flujo: `/ping` debe ser un contrato estable con version, digest y token del intento, y el bootstrap no debería terminar sin más si desktop/systemd sigue su PID; para el MVP puede quedarse como supervisor mínimo, reenviar señales y esperar al daemon hijo. Con esas condiciones, iría por este diseño y empezaría con un spike de bootstrap + pointer atómico + health/rollback antes de integrar las descargas reales.

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -821,6 +821,26 @@ const docTemplate = `{
                 }
             }
         },
+        "/ping": {
+            "get": {
+                "description": "Returns the build and update-attempt identity of the daemon serving the active listener.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "system"
+                ],
+                "summary": "Read daemon readiness identity",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_api_endpoints_ping.response"
+                        }
+                    }
+                }
+            }
+        },
         "/runtime/{ns}/{method}": {
             "post": {
                 "description": "Triggers a lifecycle method on an arrow (install, uninstall, execute, stop, update, or any custom method defined in the manifest). Returns 202 Accepted immediately; progress is streamed via WebSocket.",
@@ -1895,6 +1915,26 @@ const docTemplate = `{
                 "ProtocolUDP",
                 "ProtocolTCPUDP"
             ]
+        },
+        "internal_api_endpoints_ping.response": {
+            "type": "object",
+            "properties": {
+                "attempt_token": {
+                    "type": "string"
+                },
+                "build_id": {
+                    "type": "string"
+                },
+                "digest": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
+                }
+            }
         }
     }
 }`

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -815,6 +815,26 @@
                 }
             }
         },
+        "/ping": {
+            "get": {
+                "description": "Returns the build and update-attempt identity of the daemon serving the active listener.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "system"
+                ],
+                "summary": "Read daemon readiness identity",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_api_endpoints_ping.response"
+                        }
+                    }
+                }
+            }
+        },
         "/runtime/{ns}/{method}": {
             "post": {
                 "description": "Triggers a lifecycle method on an arrow (install, uninstall, execute, stop, update, or any custom method defined in the manifest). Returns 202 Accepted immediately; progress is streamed via WebSocket.",
@@ -1889,6 +1909,26 @@
                 "ProtocolUDP",
                 "ProtocolTCPUDP"
             ]
+        },
+        "internal_api_endpoints_ping.response": {
+            "type": "object",
+            "properties": {
+                "attempt_token": {
+                    "type": "string"
+                },
+                "build_id": {
+                    "type": "string"
+                },
+                "digest": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
+                }
+            }
         }
     }
 }

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -571,6 +571,19 @@ definitions:
     - ProtocolTCP
     - ProtocolUDP
     - ProtocolTCPUDP
+  internal_api_endpoints_ping.response:
+    properties:
+      attempt_token:
+        type: string
+      build_id:
+        type: string
+      digest:
+        type: string
+      status:
+        type: string
+      version:
+        type: string
+    type: object
 host: localhost:40257
 info:
   contact:
@@ -1089,6 +1102,20 @@ paths:
               type: string
             type: object
       summary: Health check
+      tags:
+      - system
+  /ping:
+    get:
+      description: Returns the build and update-attempt identity of the daemon serving
+        the active listener.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_api_endpoints_ping.response'
+      summary: Read daemon readiness identity
       tags:
       - system
   /runtime/{ns}/{method}:

--- a/internal/api/build_info.go
+++ b/internal/api/build_info.go
@@ -1,7 +1,6 @@
 package api
 
-// BuildInfo carries build-time version data injected via ldflags.
-type BuildInfo struct {
-	Version string
-	BuildID string
-}
+import "github.com/rabbytesoftware/quiver.core/internal/core/build"
+
+// BuildInfo carries build identity and update-attempt data into the API.
+type BuildInfo = build.Info

--- a/internal/api/container.go
+++ b/internal/api/container.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/rabbytesoftware/quiver.core/internal/api/endpoints/ping"
 	"github.com/rabbytesoftware/quiver.core/internal/api/endpoints/versions"
 	"github.com/rabbytesoftware/quiver.core/internal/api/middleware"
 )
@@ -44,6 +45,8 @@ func New(
 	latest := supported[len(supported)-1]
 
 	vh := versions.New(buildInfo.Version, buildInfo.BuildID, supported, latest)
+	ph := ping.New(buildInfo)
+	r.GET("/ping", ph.Get)
 	r.GET("/versions", vh.Get)
 
 	for _, v := range vs {

--- a/internal/api/container_test.go
+++ b/internal/api/container_test.go
@@ -22,7 +22,12 @@ func newTestContainer(t *testing.T) *api.Container {
 	t.Helper()
 	v0, err := apiv0.New(&app.Container{})
 	require.NoError(t, err)
-	c, err := api.New(api.NewHub(), api.BuildInfo{Version: "0.0.0", BuildID: "0"}, v0)
+	c, err := api.New(api.NewHub(), api.BuildInfo{
+		Version:      "0.0.0",
+		BuildID:      "0",
+		Digest:       "digest",
+		AttemptToken: "attempt",
+	}, v0)
 	require.NoError(t, err)
 	return c
 }
@@ -73,6 +78,32 @@ func TestAPIContainer_ServeHTTP_VersionsRoute_Returns200(t *testing.T) {
 	assert.Equal(t, "0", resp.Data.BuildID)
 	assert.Equal(t, []string{"v0"}, resp.Data.API.Supported)
 	assert.Equal(t, "v0", resp.Data.API.Latest)
+}
+
+func TestAPIContainer_ServeHTTP_PingRoute_ReturnsBuildIdentity(t *testing.T) {
+	c := newTestContainer(t)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/ping", nil)
+	c.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp struct {
+		Success bool `json:"success"`
+		Data    struct {
+			Status       string `json:"status"`
+			Version      string `json:"version"`
+			BuildID      string `json:"build_id"`
+			Digest       string `json:"digest"`
+			AttemptToken string `json:"attempt_token"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Success)
+	assert.Equal(t, "ready", resp.Data.Status)
+	assert.Equal(t, "0.0.0", resp.Data.Version)
+	assert.Equal(t, "0", resp.Data.BuildID)
+	assert.Equal(t, "digest", resp.Data.Digest)
+	assert.Equal(t, "attempt", resp.Data.AttemptToken)
 }
 
 func TestAPIContainer_Run_ServesAndShutdown(t *testing.T) {

--- a/internal/api/endpoints/ping/handler.go
+++ b/internal/api/endpoints/ping/handler.go
@@ -1,0 +1,36 @@
+package ping
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"github.com/rabbytesoftware/quiver.core/internal/api/libs"
+	"github.com/rabbytesoftware/quiver.core/internal/core/build"
+)
+
+// Handler serves the stable readiness contract used by the update bootstrap.
+type Handler struct {
+	info build.Info
+}
+
+// New returns a readiness handler for info.
+func New(info build.Info) *Handler {
+	return &Handler{info: info}
+}
+
+// Get reports the identity of the daemon that owns the active listener.
+//
+// @Summary      Read daemon readiness identity
+// @Description  Returns the build and update-attempt identity of the daemon serving the active listener.
+// @Tags         system
+// @Produce      json
+// @Success      200  {object}  response
+// @Router       /ping [get]
+func (h *Handler) Get(c *gin.Context) {
+	libs.WriteQueryOK(c, response{
+		Status:       "ready",
+		Version:      h.info.Version,
+		BuildID:      h.info.BuildID,
+		Digest:       h.info.Digest,
+		AttemptToken: h.info.AttemptToken,
+	})
+}

--- a/internal/api/endpoints/ping/handler_test.go
+++ b/internal/api/endpoints/ping/handler_test.go
@@ -1,0 +1,68 @@
+package ping_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rabbytesoftware/quiver.core/internal/api/endpoints/ping"
+	"github.com/rabbytesoftware/quiver.core/internal/core/build"
+)
+
+func TestHandler_Get_ReturnsBuildAndAttemptIdentity(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := ping.New(build.Info{
+		Version:      "25.9.1",
+		BuildID:      "123",
+		Digest:       "abc123",
+		AttemptToken: "attempt-token",
+	})
+	router := gin.New()
+	router.GET("/ping", h.Get)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/ping", nil))
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var body struct {
+		Success bool `json:"success"`
+		Data    struct {
+			Status       string `json:"status"`
+			Version      string `json:"version"`
+			BuildID      string `json:"build_id"`
+			Digest       string `json:"digest"`
+			AttemptToken string `json:"attempt_token"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.True(t, body.Success)
+	assert.Equal(t, "ready", body.Data.Status)
+	assert.Equal(t, "25.9.1", body.Data.Version)
+	assert.Equal(t, "123", body.Data.BuildID)
+	assert.Equal(t, "abc123", body.Data.Digest)
+	assert.Equal(t, "attempt-token", body.Data.AttemptToken)
+}
+
+func TestHandler_Get_WithoutAttempt_PreservesStableShape(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := ping.New(build.Info{Version: "25.9.1", BuildID: "123", Digest: "abc123"})
+	router := gin.New()
+	router.GET("/ping", h.Get)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/ping", nil))
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	data, ok := body["data"].(map[string]any)
+	require.True(t, ok)
+	value, exists := data["attempt_token"]
+	assert.True(t, exists)
+	assert.Equal(t, "", value)
+}

--- a/internal/api/endpoints/ping/response.go
+++ b/internal/api/endpoints/ping/response.go
@@ -1,0 +1,9 @@
+package ping
+
+type response struct {
+	Status       string `json:"status"`
+	Version      string `json:"version"`
+	BuildID      string `json:"build_id"`
+	Digest       string `json:"digest"`
+	AttemptToken string `json:"attempt_token"`
+}

--- a/internal/core/build/digest.go
+++ b/internal/core/build/digest.go
@@ -1,0 +1,54 @@
+package build
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io"
+
+	"github.com/rabbytesoftware/quiver.core/internal/core/fns"
+)
+
+// Digest returns the SHA-256 digest of the file at path.
+func Digest(
+	ctx context.Context,
+	path string,
+) (string, error) {
+	reader, err := fns.ReadStream(ctx, path)
+	if err != nil {
+		return "", fmt.Errorf("build digest: open executable: %w", err)
+	}
+	digest, err := digestReader(ctx, reader)
+	if err != nil {
+		return "", fmt.Errorf("build digest: %w", err)
+	}
+	return digest, nil
+}
+
+func digestReader(ctx context.Context, reader io.ReadCloser) (string, error) {
+	hash := sha256.New()
+	_, copyErr := io.Copy(hash, &contextReader{ctx: ctx, reader: reader})
+	closeErr := reader.Close()
+	if copyErr != nil {
+		return "", fmt.Errorf("read executable: %w", copyErr)
+	}
+	if closeErr != nil {
+		return "", fmt.Errorf("close executable: %w", closeErr)
+	}
+
+	return fmt.Sprintf("%x", hash.Sum(nil)), nil
+}
+
+type contextReader struct {
+	ctx    context.Context
+	reader io.Reader
+}
+
+func (r *contextReader) Read(p []byte) (int, error) {
+	select {
+	case <-r.ctx.Done():
+		return 0, r.ctx.Err()
+	default:
+		return r.reader.Read(p)
+	}
+}

--- a/internal/core/build/digest_test.go
+++ b/internal/core/build/digest_test.go
@@ -1,0 +1,89 @@
+package build
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/rabbytesoftware/quiver.core/internal/core/fns"
+)
+
+func TestDigest_ExistingFile_ReturnsSHA256(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "quiver")
+	require.NoError(t, fns.Write(context.Background(), path, []byte("candidate")))
+
+	got, err := Digest(context.Background(), path)
+
+	require.NoError(t, err)
+	want := sha256.Sum256([]byte("candidate"))
+	assert.Equal(t, fmt.Sprintf("%x", want), got)
+}
+
+func TestDigest_MissingFile_ReturnsError(t *testing.T) {
+	got, err := Digest(context.Background(), filepath.Join(t.TempDir(), "missing"))
+
+	require.Error(t, err)
+	assert.Empty(t, got)
+}
+
+func TestDigest_CancelledContext_ReturnsError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "quiver")
+	require.NoError(t, fns.Write(context.Background(), path, []byte("candidate")))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	got, err := Digest(ctx, path)
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Empty(t, got)
+}
+
+func TestDigestReader_ReadFailureReturnsError(t *testing.T) {
+	wantErr := errors.New("read failed")
+	reader := &stubReadCloser{reader: errorReader{err: wantErr}}
+
+	got, err := digestReader(context.Background(), reader)
+
+	require.ErrorIs(t, err, wantErr)
+	assert.Empty(t, got)
+	assert.True(t, reader.closed)
+}
+
+func TestDigestReader_CloseFailureReturnsError(t *testing.T) {
+	wantErr := errors.New("close failed")
+	reader := &stubReadCloser{reader: bytes.NewReader([]byte("candidate")), closeErr: wantErr}
+
+	got, err := digestReader(context.Background(), reader)
+
+	require.ErrorIs(t, err, wantErr)
+	assert.Empty(t, got)
+}
+
+type stubReadCloser struct {
+	reader   io.Reader
+	closeErr error
+	closed   bool
+}
+
+func (r *stubReadCloser) Read(p []byte) (int, error) {
+	return r.reader.Read(p)
+}
+
+func (r *stubReadCloser) Close() error {
+	r.closed = true
+	return r.closeErr
+}
+
+type errorReader struct{ err error }
+
+func (r errorReader) Read([]byte) (int, error) {
+	return 0, r.err
+}

--- a/internal/core/build/info.go
+++ b/internal/core/build/info.go
@@ -1,0 +1,9 @@
+package build
+
+// Info identifies one running Quiver build and an optional update attempt.
+type Info struct {
+	Version      string
+	BuildID      string
+	Digest       string
+	AttemptToken string
+}

--- a/internal/engine/updater/errors.go
+++ b/internal/engine/updater/errors.go
@@ -1,0 +1,9 @@
+package updater
+
+import "errors"
+
+var (
+	ErrInvalidLayout = errors.New("updater: invalid layout")
+	ErrInvalidState  = errors.New("updater: invalid state")
+	ErrUnsafePath    = errors.New("updater: unsafe path")
+)

--- a/internal/engine/updater/layout.go
+++ b/internal/engine/updater/layout.go
@@ -1,0 +1,159 @@
+package updater
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+)
+
+// SystemNamespace identifies the protected built-in Quiver Arrow.
+const SystemNamespace = "github.com/rabbytesoftware/quiver"
+
+// MaxVersionLength keeps the content-addressed directory name portable.
+const MaxVersionLength = 64
+
+// Layout contains the trusted filesystem roots used by self-update state.
+type Layout struct {
+	namespaces     string
+	root           string
+	versions       string
+	update         string
+	executableName string
+}
+
+// NewLayout resolves the protected Quiver Arrow update layout below namespacesPath.
+func NewLayout(namespacesPath string) (Layout, error) {
+	return newLayout(namespacesPath, runtime.GOOS)
+}
+
+func newLayout(namespacesPath, goos string) (Layout, error) {
+	if namespacesPath == "" || !filepath.IsAbs(namespacesPath) {
+		return Layout{}, fmt.Errorf("updater layout: namespaces path must be absolute: %w", ErrInvalidLayout)
+	}
+	if goos == "" {
+		return Layout{}, fmt.Errorf("updater layout: operating system is required: %w", ErrInvalidLayout)
+	}
+
+	root := filepath.Join(namespacesPath, filepath.FromSlash(SystemNamespace))
+	executableName := "quiver"
+	if goos == "windows" {
+		executableName += ".exe"
+	}
+
+	return Layout{
+		namespaces:     filepath.Clean(namespacesPath),
+		root:           root,
+		versions:       filepath.Join(root, "versions"),
+		update:         filepath.Join(root, "update"),
+		executableName: executableName,
+	}, nil
+}
+
+// Root returns the protected Quiver Arrow workdir used by the updater.
+func (l Layout) Root() string {
+	return l.root
+}
+
+// VersionsDir returns the immutable version store directory.
+func (l Layout) VersionsDir() string {
+	return l.versions
+}
+
+// UpdateDir returns the directory containing update transaction state.
+func (l Layout) UpdateDir() string {
+	return l.update
+}
+
+// CurrentPath returns the active selection pointer path.
+func (l Layout) CurrentPath() string {
+	if l.validate() != nil {
+		return ""
+	}
+	return filepath.Join(l.update, "current.json")
+}
+
+// StagedPath returns the verified candidate pointer path.
+func (l Layout) StagedPath() string {
+	if l.validate() != nil {
+		return ""
+	}
+	return filepath.Join(l.update, "staged.json")
+}
+
+// AttemptPath returns the in-flight activation record path.
+func (l Layout) AttemptPath() string {
+	if l.validate() != nil {
+		return ""
+	}
+	return filepath.Join(l.update, "attempt.json")
+}
+
+func (l Layout) artifact(version, digest string) (Artifact, error) {
+	if err := l.validate(); err != nil {
+		return Artifact{}, err
+	}
+	if err := validateVersion(version); err != nil {
+		return Artifact{}, err
+	}
+	if err := validateDigest(digest); err != nil {
+		return Artifact{}, err
+	}
+
+	dirName := version + "-" + digest
+	relative := filepath.ToSlash(filepath.Join("versions", dirName, l.executableName))
+	return Artifact{Version: version, Digest: digest, Executable: relative}, nil
+}
+
+func validateVersion(version string) error {
+	if version == "" {
+		return fmt.Errorf("updater version: value is required: %w", ErrInvalidState)
+	}
+	if len(version) > MaxVersionLength {
+		return fmt.Errorf("updater version: exceeds %d bytes: %w", MaxVersionLength, ErrInvalidState)
+	}
+	for _, char := range version {
+		if isVersionChar(char) {
+			continue
+		}
+		return fmt.Errorf("updater version %q: unsupported character: %w", version, ErrInvalidState)
+	}
+	return nil
+}
+
+func (l Layout) validate() error {
+	paths := []string{l.namespaces, l.root, l.versions, l.update}
+	for _, path := range paths {
+		if path == "" || !filepath.IsAbs(path) || filepath.Clean(path) != path {
+			return fmt.Errorf("updater layout: invalid absolute path: %w", ErrInvalidLayout)
+		}
+	}
+
+	wantRoot := filepath.Join(l.namespaces, filepath.FromSlash(SystemNamespace))
+	if l.root != wantRoot || l.versions != filepath.Join(wantRoot, "versions") || l.update != filepath.Join(wantRoot, "update") {
+		return fmt.Errorf("updater layout: roots are inconsistent: %w", ErrInvalidLayout)
+	}
+	if l.executableName != "quiver" && l.executableName != "quiver.exe" {
+		return fmt.Errorf("updater layout: invalid executable name: %w", ErrInvalidLayout)
+	}
+	return nil
+}
+
+func isVersionChar(char rune) bool {
+	return char >= 'a' && char <= 'z' ||
+		char >= 'A' && char <= 'Z' ||
+		char >= '0' && char <= '9' ||
+		char == '.' || char == '-' || char == '_' || char == '+'
+}
+
+func validateDigest(digest string) error {
+	if len(digest) != 64 {
+		return fmt.Errorf("updater digest: expected 64 lowercase hexadecimal characters: %w", ErrInvalidState)
+	}
+	for _, char := range digest {
+		if char >= '0' && char <= '9' || char >= 'a' && char <= 'f' {
+			continue
+		}
+		return fmt.Errorf("updater digest: expected lowercase hexadecimal: %w", ErrInvalidState)
+	}
+	return nil
+}

--- a/internal/engine/updater/layout_test.go
+++ b/internal/engine/updater/layout_test.go
@@ -1,0 +1,127 @@
+package updater
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testDigest = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+func TestNewLayout_AbsolutePath_ReturnsSystemArrowLayout(t *testing.T) {
+	namespaces := t.TempDir()
+
+	layout, err := newLayout(namespaces, "linux")
+
+	require.NoError(t, err)
+	wantRoot := filepath.Join(namespaces, filepath.FromSlash(SystemNamespace))
+	assert.Equal(t, wantRoot, layout.Root())
+	assert.Equal(t, filepath.Join(wantRoot, "versions"), layout.VersionsDir())
+	assert.Equal(t, filepath.Join(wantRoot, "update"), layout.UpdateDir())
+	assert.Equal(t, filepath.Join(wantRoot, "update", "current.json"), layout.CurrentPath())
+	assert.Equal(t, filepath.Join(wantRoot, "update", "staged.json"), layout.StagedPath())
+	assert.Equal(t, filepath.Join(wantRoot, "update", "attempt.json"), layout.AttemptPath())
+}
+
+func TestNewLayout_Windows_UsesExecutableSuffix(t *testing.T) {
+	layout, err := newLayout(t.TempDir(), "windows")
+	require.NoError(t, err)
+
+	artifact, err := NewArtifact(layout, "v1.2.3", testDigest)
+
+	require.NoError(t, err)
+	assert.True(t, strings.HasSuffix(artifact.Executable, "/quiver.exe"))
+}
+
+func TestNewLayout_RuntimeOS_ReturnsLayout(t *testing.T) {
+	layout, err := NewLayout(t.TempDir())
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, layout.Root())
+}
+
+func TestNewLayout_InvalidInputs_ReturnErrors(t *testing.T) {
+	testCases := []struct {
+		name       string
+		namespaces string
+		goos       string
+	}{
+		{name: "empty path", goos: "linux"},
+		{name: "relative path", namespaces: "namespaces", goos: "linux"},
+		{name: "empty operating system", namespaces: t.TempDir()},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			layout, err := newLayout(tc.namespaces, tc.goos)
+
+			require.ErrorIs(t, err, ErrInvalidLayout)
+			assert.Empty(t, layout.Root())
+		})
+	}
+}
+
+func TestLayout_ZeroValue_IsRejectedByOperationalMethods(t *testing.T) {
+	layout := Layout{}
+
+	artifact, err := NewArtifact(layout, "v1", testDigest)
+	require.ErrorIs(t, err, ErrInvalidLayout)
+	assert.Empty(t, artifact)
+	assert.Empty(t, layout.CurrentPath())
+	assert.Empty(t, layout.StagedPath())
+	assert.Empty(t, layout.AttemptPath())
+}
+
+func TestNewArtifact_ValidIdentity_ReturnsCanonicalRelativePath(t *testing.T) {
+	layout, err := newLayout(t.TempDir(), "linux")
+	require.NoError(t, err)
+
+	artifact, err := NewArtifact(layout, "v1.2.3-rc.1+build_4", testDigest)
+
+	require.NoError(t, err)
+	assert.Equal(t, "v1.2.3-rc.1+build_4", artifact.Version)
+	assert.Equal(t, testDigest, artifact.Digest)
+	assert.Equal(t, "versions/v1.2.3-rc.1+build_4-"+testDigest+"/quiver", artifact.Executable)
+}
+
+func TestNewArtifact_InvalidIdentity_ReturnsError(t *testing.T) {
+	layout, err := newLayout(t.TempDir(), "linux")
+	require.NoError(t, err)
+	testCases := []struct {
+		name    string
+		version string
+		digest  string
+	}{
+		{name: "empty version", digest: testDigest},
+		{name: "version traversal", version: "../v1", digest: testDigest},
+		{name: "version too long", version: strings.Repeat("v", MaxVersionLength+1), digest: testDigest},
+		{name: "short digest", version: "v1", digest: "abc"},
+		{name: "uppercase digest", version: "v1", digest: strings.ToUpper(testDigest)},
+		{name: "non hexadecimal digest", version: "v1", digest: strings.Repeat("z", 64)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			artifact, artifactErr := NewArtifact(layout, tc.version, tc.digest)
+
+			require.ErrorIs(t, artifactErr, ErrInvalidState)
+			assert.Empty(t, artifact)
+		})
+	}
+}
+
+func TestArtifact_Validate_UnsafePathReturnsError(t *testing.T) {
+	layout, err := newLayout(t.TempDir(), "linux")
+	require.NoError(t, err)
+	artifact, err := NewArtifact(layout, "v1", testDigest)
+	require.NoError(t, err)
+	artifact.Executable = "../../quiver"
+
+	err = artifact.Validate(layout)
+
+	require.True(t, errors.Is(err, ErrUnsafePath))
+}

--- a/internal/engine/updater/state.go
+++ b/internal/engine/updater/state.go
@@ -1,0 +1,155 @@
+package updater
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+)
+
+// StateSchema is the current on-disk updater state schema.
+const StateSchema = 1
+
+// Artifact identifies one immutable, content-addressed Quiver executable.
+type Artifact struct {
+	Version    string `json:"version" yaml:"version"`
+	Digest     string `json:"digest" yaml:"digest"`
+	Executable string `json:"executable" yaml:"executable"`
+}
+
+// NewArtifact returns the canonical artifact identity for version and digest.
+func NewArtifact(layout Layout, version, digest string) (Artifact, error) {
+	return layout.artifact(version, digest)
+}
+
+// Validate confirms that the artifact is canonical and contained by layout.
+func (a Artifact) Validate(layout Layout) error {
+	expected, err := layout.artifact(a.Version, a.Digest)
+	if err != nil {
+		return err
+	}
+	if a.Executable != expected.Executable {
+		return fmt.Errorf("updater artifact executable %q: expected %q: %w", a.Executable, expected.Executable, ErrUnsafePath)
+	}
+	return nil
+}
+
+// Selection identifies the active and previous verified Quiver artifacts.
+type Selection struct {
+	Schema     int       `json:"schema" yaml:"schema"`
+	Generation uint64    `json:"generation" yaml:"generation"`
+	Current    Artifact  `json:"current" yaml:"current"`
+	Previous   *Artifact `json:"previous,omitempty" yaml:"previous,omitempty"`
+	PromotedAt time.Time `json:"promoted_at" yaml:"promoted_at"`
+}
+
+// Validate confirms that the selection identifies canonical, distinct artifacts.
+func (s Selection) Validate(layout Layout) error {
+	if s.Schema != StateSchema {
+		return fmt.Errorf("updater selection schema %d: expected %d: %w", s.Schema, StateSchema, ErrInvalidState)
+	}
+	if s.Generation == 0 {
+		return fmt.Errorf("updater selection generation: value is required: %w", ErrInvalidState)
+	}
+	if err := s.Current.Validate(layout); err != nil {
+		return fmt.Errorf("updater selection current: %w", err)
+	}
+	if s.PromotedAt.IsZero() {
+		return fmt.Errorf("updater selection promoted_at: value is required: %w", ErrInvalidState)
+	}
+	if s.Previous == nil {
+		return nil
+	}
+	if err := s.Previous.Validate(layout); err != nil {
+		return fmt.Errorf("updater selection previous: %w", err)
+	}
+	if s.Previous.Digest == s.Current.Digest {
+		return fmt.Errorf("updater selection previous: duplicates current digest: %w", ErrInvalidState)
+	}
+	return nil
+}
+
+// Staged identifies a verified candidate awaiting a bootstrap attempt.
+type Staged struct {
+	Schema     int       `json:"schema" yaml:"schema"`
+	Candidate  Artifact  `json:"candidate" yaml:"candidate"`
+	PreparedAt time.Time `json:"prepared_at" yaml:"prepared_at"`
+}
+
+// Validate confirms that the staged candidate is canonical and timestamped.
+func (s Staged) Validate(layout Layout) error {
+	if s.Schema != StateSchema {
+		return fmt.Errorf("updater staged schema %d: expected %d: %w", s.Schema, StateSchema, ErrInvalidState)
+	}
+	if err := s.Candidate.Validate(layout); err != nil {
+		return fmt.Errorf("updater staged candidate: %w", err)
+	}
+	if s.PreparedAt.IsZero() {
+		return fmt.Errorf("updater staged prepared_at: value is required: %w", ErrInvalidState)
+	}
+	return nil
+}
+
+// EncodeSelection validates and serializes a selection using the stable schema.
+func EncodeSelection(layout Layout, selection Selection) ([]byte, error) {
+	if err := selection.Validate(layout); err != nil {
+		return nil, err
+	}
+	return encode(selection)
+}
+
+// DecodeSelection parses one strict selection document and validates its paths.
+func DecodeSelection(layout Layout, data []byte) (Selection, error) {
+	var selection Selection
+	if err := decode(data, &selection); err != nil {
+		return Selection{}, fmt.Errorf("updater selection: decode: %w", err)
+	}
+	if err := selection.Validate(layout); err != nil {
+		return Selection{}, err
+	}
+	return selection, nil
+}
+
+// EncodeStaged validates and serializes a staged candidate using the stable schema.
+func EncodeStaged(layout Layout, staged Staged) ([]byte, error) {
+	if err := staged.Validate(layout); err != nil {
+		return nil, err
+	}
+	return encode(staged)
+}
+
+// DecodeStaged parses one strict staged document and validates its paths.
+func DecodeStaged(layout Layout, data []byte) (Staged, error) {
+	var staged Staged
+	if err := decode(data, &staged); err != nil {
+		return Staged{}, fmt.Errorf("updater staged: decode: %w", err)
+	}
+	if err := staged.Validate(layout); err != nil {
+		return Staged{}, err
+	}
+	return staged, nil
+}
+
+func encode(value any) ([]byte, error) {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("updater state: encode: %w", err)
+	}
+	return append(data, '\n'), nil
+}
+
+func decode(data []byte, value any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(value); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("multiple JSON values")
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/engine/updater/state_test.go
+++ b/internal/engine/updater/state_test.go
@@ -1,0 +1,197 @@
+package updater
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestState(t *testing.T) (Layout, Artifact, Artifact) {
+	t.Helper()
+	layout, err := newLayout(t.TempDir(), "linux")
+	require.NoError(t, err)
+	current, err := NewArtifact(layout, "v1.0.0", testDigest)
+	require.NoError(t, err)
+	previousDigest := "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+	previous, err := NewArtifact(layout, "v0.9.0", previousDigest)
+	require.NoError(t, err)
+	return layout, current, previous
+}
+
+func TestSelection_Validate_ValidSelectionReturnsNil(t *testing.T) {
+	layout, current, previous := newTestState(t)
+	selection := Selection{
+		Schema:     StateSchema,
+		Generation: 2,
+		Current:    current,
+		Previous:   &previous,
+		PromotedAt: time.Now().UTC(),
+	}
+
+	assert.NoError(t, selection.Validate(layout))
+}
+
+func TestSelection_Validate_FirstSelectionWithoutPreviousReturnsNil(t *testing.T) {
+	layout, current, _ := newTestState(t)
+	selection := Selection{
+		Schema:     StateSchema,
+		Generation: 1,
+		Current:    current,
+		PromotedAt: time.Now().UTC(),
+	}
+
+	assert.NoError(t, selection.Validate(layout))
+}
+
+func TestSelection_Validate_InvalidFieldsReturnError(t *testing.T) {
+	layout, current, previous := newTestState(t)
+	now := time.Now().UTC()
+	testCases := []struct {
+		name      string
+		selection Selection
+		want      error
+	}{
+		{name: "schema", selection: Selection{Generation: 1, Current: current, PromotedAt: now}, want: ErrInvalidState},
+		{name: "generation", selection: Selection{Schema: StateSchema, Current: current, PromotedAt: now}, want: ErrInvalidState},
+		{name: "current", selection: Selection{Schema: StateSchema, Generation: 1, PromotedAt: now}, want: ErrInvalidState},
+		{name: "promoted at", selection: Selection{Schema: StateSchema, Generation: 1, Current: current}, want: ErrInvalidState},
+		{name: "previous", selection: Selection{Schema: StateSchema, Generation: 2, Current: current, Previous: &Artifact{}, PromotedAt: now}, want: ErrInvalidState},
+		{name: "duplicate previous", selection: Selection{Schema: StateSchema, Generation: 2, Current: current, Previous: &current, PromotedAt: now}, want: ErrInvalidState},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.selection.Validate(layout)
+
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, tc.want))
+		})
+	}
+	_ = previous
+}
+
+func TestStaged_Validate_ValidStateReturnsNil(t *testing.T) {
+	layout, current, _ := newTestState(t)
+	staged := Staged{Schema: StateSchema, Candidate: current, PreparedAt: time.Now().UTC()}
+
+	assert.NoError(t, staged.Validate(layout))
+}
+
+func TestStaged_Validate_InvalidFieldsReturnError(t *testing.T) {
+	layout, current, _ := newTestState(t)
+	now := time.Now().UTC()
+	testCases := []struct {
+		name   string
+		staged Staged
+	}{
+		{name: "schema", staged: Staged{Candidate: current, PreparedAt: now}},
+		{name: "candidate", staged: Staged{Schema: StateSchema, PreparedAt: now}},
+		{name: "prepared at", staged: Staged{Schema: StateSchema, Candidate: current}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.staged.Validate(layout)
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrInvalidState)
+		})
+	}
+}
+
+func TestSelection_EncodeDecode_RoundTrips(t *testing.T) {
+	layout, current, previous := newTestState(t)
+	selection := Selection{
+		Schema:     StateSchema,
+		Generation: 2,
+		Current:    current,
+		Previous:   &previous,
+		PromotedAt: time.Now().UTC().Truncate(time.Second),
+	}
+
+	data, err := EncodeSelection(layout, selection)
+	require.NoError(t, err)
+	decoded, err := DecodeSelection(layout, data)
+
+	require.NoError(t, err)
+	assert.Equal(t, selection, decoded)
+	assert.Equal(t, byte('\n'), data[len(data)-1])
+}
+
+func TestSelection_Encode_InvalidStateReturnsError(t *testing.T) {
+	layout, _, _ := newTestState(t)
+
+	data, err := EncodeSelection(layout, Selection{})
+
+	require.ErrorIs(t, err, ErrInvalidState)
+	assert.Nil(t, data)
+}
+
+func TestSelection_Decode_InvalidDocumentsReturnError(t *testing.T) {
+	layout, _, _ := newTestState(t)
+	testCases := []struct {
+		name string
+		data string
+	}{
+		{name: "malformed", data: "{"},
+		{name: "unknown field", data: `{"schema":1,"unknown":true}`},
+		{name: "multiple values", data: `{} {}`},
+		{name: "invalid state", data: `{}`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			selection, err := DecodeSelection(layout, []byte(tc.data))
+
+			require.Error(t, err)
+			assert.Empty(t, selection)
+		})
+	}
+}
+
+func TestStaged_EncodeDecode_RoundTrips(t *testing.T) {
+	layout, current, _ := newTestState(t)
+	staged := Staged{
+		Schema:     StateSchema,
+		Candidate:  current,
+		PreparedAt: time.Now().UTC().Truncate(time.Second),
+	}
+
+	data, err := EncodeStaged(layout, staged)
+	require.NoError(t, err)
+	decoded, err := DecodeStaged(layout, data)
+
+	require.NoError(t, err)
+	assert.Equal(t, staged, decoded)
+}
+
+func TestStaged_Encode_InvalidStateReturnsError(t *testing.T) {
+	layout, _, _ := newTestState(t)
+
+	data, err := EncodeStaged(layout, Staged{})
+
+	require.ErrorIs(t, err, ErrInvalidState)
+	assert.Nil(t, data)
+}
+
+func TestStaged_Decode_InvalidDocumentsReturnError(t *testing.T) {
+	layout, _, _ := newTestState(t)
+	testCases := []string{"{", `{"unknown":true}`, `{} {}`, `{}`}
+
+	for _, data := range testCases {
+		staged, err := DecodeStaged(layout, []byte(data))
+
+		require.Error(t, err)
+		assert.Empty(t, staged)
+	}
+}
+
+func TestEncode_UnsupportedValueReturnsError(t *testing.T) {
+	data, err := encode(func() {})
+
+	require.Error(t, err)
+	assert.Nil(t, data)
+}

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rabbytesoftware/quiver.core/internal/api"
 	apiv0 "github.com/rabbytesoftware/quiver.core/internal/api/v0"
 	"github.com/rabbytesoftware/quiver.core/internal/app"
+	"github.com/rabbytesoftware/quiver.core/internal/core/build"
 	"github.com/rabbytesoftware/quiver.core/internal/core/config"
 	"github.com/rabbytesoftware/quiver.core/internal/core/gateway"
 	"github.com/rabbytesoftware/quiver.core/internal/core/shutdown"
@@ -122,8 +123,7 @@ func WithHomeDir(dir string) Option {
 // New wires all internal modules together: engine + adapter → app → api.
 func New(
 	ctx context.Context,
-	version string,
-	buildID string,
+	buildInfo build.Info,
 	opts ...Option,
 ) (*Container, error) {
 	cfg := internalOpts{}
@@ -151,7 +151,7 @@ func New(
 		return nil, fmt.Errorf("internal: api/v0: %w", err)
 	}
 
-	apiContainer, err := api.New(appContainer.Hub, api.BuildInfo{Version: version, BuildID: buildID}, v0Container)
+	apiContainer, err := api.New(appContainer.Hub, buildInfo, v0Container)
 	if err != nil {
 		return nil, fmt.Errorf("internal: api: %w", err)
 	}

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -8,12 +8,17 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/rabbytesoftware/quiver.core/internal/core/build"
 )
 
 func newTestContainer(t *testing.T) *Container {
 	t.Helper()
 
-	c, err := New(context.Background(), "v0.0.0-test", "test-build", WithHomeDir(t.TempDir()))
+	c, err := New(context.Background(), build.Info{
+		Version: "v0.0.0-test",
+		BuildID: "test-build",
+	}, WithHomeDir(t.TempDir()))
 	require.NoError(t, err)
 	return c
 }
@@ -42,7 +47,10 @@ func TestNew_UnusableHome_ReturnsEngineError(t *testing.T) {
 	home := filepath.Join(t.TempDir(), "home")
 	require.NoError(t, os.WriteFile(home, []byte("not a directory"), 0o600))
 
-	_, err := New(context.Background(), "v0.0.0-test", "test-build", WithHomeDir(home))
+	_, err := New(context.Background(), build.Info{
+		Version: "v0.0.0-test",
+		BuildID: "test-build",
+	}, WithHomeDir(home))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "internal: engine")
 }


### PR DESCRIPTION
## Description

Introduces the first safe foundation for Quiver self-update without replacing or launching binaries yet.

The slice adds a stable readiness identity, real executable digests, and strict lexical models for versioned update state. Physical artifact I/O and activation remain explicitly deferred until they can use platform-specific no-follow/handle-scoped operations.

## Type of Change

- [ ] 🐛 Bug fix (fix/*)
- [x] ✨ New feature (feature/*)
- [ ] 🔧 Enhancement (enhancement/*)
- [ ] 🚑 Hotfix (hotfix/*)
- [ ] 🚀 Release (release/*)

## Related Issues

Related to #163

## Changes Made

- Add the unversioned `GET /ping` readiness contract with version, build ID, SHA-256 digest, and per-attempt token.
- Compute the running executable digest before `internal.New` and pass build identity through a dedicated value object.
- Add canonical, content-addressed updater layout plus strict `current` and `staged` state validation/serialization.
- Keep the attempt token out of process arguments by accepting it only through `QUIVER_UPDATE_ATTEMPT_TOKEN`.
- Document the approved versioned-bootstrap architecture and the required TOCTOU-safe boundary for the next slice.
- Regenerate Swagger documentation and add focused unit/integration coverage.

## Breaking Changes

- [ ] This PR introduces breaking changes
- [ ] Migration guide provided (if yes)

## Checklist

- [x] Code follows Clean Architecture principles
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic
- [x] All documentation updated in `./docs/` folder
- [x] **🚨 Tests pass locally (`make test`)**
- [x] Coverage requirements met (`make test-coverage`)
- [x] No linting errors (`make lint`)
- [x] Security scan passes (`make security`)
- [x] Branch name follows convention (enhancement/*, feature/*, fix/*, hotfix/*, release/*)

## Verification

- `make pr-checks`
- Global coverage: 97.3%
- New package coverage: updater 97.5%, build 100%, ping 100%
- Cross-compiled updater tests for Windows AMD64 and Darwin ARM64
- Independent senior Go/security review: approved with no remaining P0–P2 findings

## Screenshots/Logs

Not applicable.